### PR TITLE
Persist and restore last searched city using localStorage

### DIFF
--- a/app.js
+++ b/app.js
@@ -1017,6 +1017,7 @@ async function tryGeolocation(model) {
 }
 async function loadAndSync(city, model) {
   setQParam(city);
+  localStorage.setItem('vejr_city', city);
   await load(city, model);
 }
 document.getElementById('search-btn').addEventListener('click', () => {
@@ -1061,7 +1062,11 @@ if (window.setRadarDragCallback) {
   } else {
     const typed = document.getElementById('city-input').value.trim();
     if (typed) { setQParam(typed); load(typed, model); }
-    else        { tryGeolocation(model); }
+    else {
+      const saved = localStorage.getItem('vejr_city');
+      if (saved) { document.getElementById('city-input').value = saved; setQParam(saved); load(saved, model); }
+      else        { tryGeolocation(model); }
+    }
   }
 })();
 // Register service worker for PWA / offline support

--- a/app.js
+++ b/app.js
@@ -1044,29 +1044,38 @@ if (window.setRadarDragCallback) {
 }
 
 // ── Initial load ──────────────────────────────────────────────────────────
+// Pure decision function: given the three possible location sources, returns
+// which one to use.  Tested directly in tests/app.test.js.
+function decideInitialLocation(qParam, typedInput, savedCity) {
+  if (qParam)     return { type: 'qparam', value: qParam };
+  if (typedInput) return { type: 'typed',  value: typedInput };
+  if (savedCity)  return { type: 'saved',  value: savedCity };
+  return            { type: 'geolocation' };
+}
+
 (function initialLoad() {
-  const model  = getModel();
-  const qParam = getQParam();
-  if (qParam) {
+  const model    = getModel();
+  const qParam   = getQParam();
+  const typed    = document.getElementById('city-input').value.trim();
+  const saved    = localStorage.getItem('vejr_city');
+  const decision = decideInitialLocation(qParam, typed, saved);
+
+  if (decision.type === 'qparam') {
     // If q looks like "lat,lon" (stored when the user dragged the pin), restore
     // the exact coordinates without going through geocoding.
-    const coordMatch = qParam.match(/^(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)$/);
+    const coordMatch = decision.value.match(/^(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)$/);
     if (coordMatch) {
-      const lat = parseFloat(coordMatch[1]);
-      const lon = parseFloat(coordMatch[2]);
-      loadAtCoords(lat, lon, model);
+      loadAtCoords(parseFloat(coordMatch[1]), parseFloat(coordMatch[2]), model);
     } else {
-      document.getElementById('city-input').value = qParam;
-      load(qParam, model);
+      document.getElementById('city-input').value = decision.value;
+      load(decision.value, model);
     }
+  } else if (decision.type === 'geolocation') {
+    tryGeolocation(model);
   } else {
-    const typed = document.getElementById('city-input').value.trim();
-    if (typed) { setQParam(typed); load(typed, model); }
-    else {
-      const saved = localStorage.getItem('vejr_city');
-      if (saved) { document.getElementById('city-input').value = saved; setQParam(saved); load(saved, model); }
-      else        { tryGeolocation(model); }
-    }
+    document.getElementById('city-input').value = decision.value;
+    setQParam(decision.value);
+    load(decision.value, model);
   }
 })();
 // Register service worker for PWA / offline support

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const ROOT    = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const APP_SRC = readFileSync(resolve(ROOT, 'app.js'), 'utf8');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEl(value = '') {
+  return {
+    value,
+    style:      {},
+    textContent: '',
+    classList:  { contains: () => false, add: () => {}, remove: () => {} },
+    addEventListener: () => {},
+  };
+}
+
+/**
+ * Load app.js in a sandboxed vm context with all browser globals mocked.
+ *
+ * @param {object} opts
+ * @param {string}  opts.qParam       – value of the `q` URL parameter (default: none)
+ * @param {string|null} opts.savedCity – value stored in localStorage under 'vejr_city'
+ * @param {boolean} opts.geoAvailable – whether navigator.geolocation is present
+ */
+function loadApp({ qParam = '', savedCity = null, geoAvailable = false } = {}) {
+  const cityInput        = makeEl();
+  const geoCalls         = [];
+  const replaceStateCalls = [];
+
+  const store = savedCity != null ? { vejr_city: savedCity } : {};
+  const mockLocalStorage = {
+    store,
+    getItem(key)        { return this.store[key] ?? null; },
+    setItem(key, value) { this.store[key] = value; },
+  };
+
+  const search = qParam ? `?q=${encodeURIComponent(qParam)}` : '';
+  const href   = `http://localhost/${search}`;
+
+  const ctx = vm.createContext({
+    window: {
+      location:             { search, href },
+      history:              { replaceState: (...a) => replaceStateCalls.push(a) },
+      addEventListener:     () => {},
+      setRadarDragCallback: null,
+      SHORE_MASK:           null,
+      SHORE_STATUS:         { state: 'idle', msg: '' },
+      SHORE_DEBUG:          null,
+      devicePixelRatio:     1,
+    },
+    document: {
+      getElementById: (id) => {
+        if (id === 'city-input')   return cityInput;
+        if (id === 'model-select') return makeEl('dmi_seamless');
+        return makeEl();
+      },
+    },
+    localStorage: mockLocalStorage,
+    navigator: geoAvailable
+      ? { geolocation: { getCurrentPosition: (ok, err, _opts) => { geoCalls.push(true); err(new Error('denied')); } } }
+      : {},
+    // Web APIs
+    URL, URLSearchParams,
+    console, Math,
+    Array, Float32Array, Set, Map,
+    Number, String, Boolean, Object,
+    parseInt, parseFloat, isNaN, isFinite,
+    encodeURIComponent, decodeURIComponent,
+    Promise, Error,
+    setTimeout, clearTimeout,
+    fetch: () => Promise.reject(new Error('fetch not mocked')),
+    // Stubs for functions/constants defined in other scripts.
+    // Use a never-settling promise so async chains stall silently rather than
+    // logging unhandled-rejection noise to stderr.
+    geocode:            () => new Promise(() => {}),
+    fetchWeather:       () => new Promise(() => {}),
+    fetchEnsemble:      () => new Promise(() => {}),
+    ensemblePercentiles: () => null,
+    renderAll:          () => {},
+    isKiteOptimal:      () => false,
+    snapBearing:        (d) => d,
+    FORECAST_DAYS:      7,
+    STEP:               3,
+    KITE_DEFAULTS:      { min: 4, max: 18, dirs: [], daylight: true },
+    KITE_CFG:           { min: 4, max: 18, dirs: [], daylight: true },
+    setKiteParams:      () => {},
+    parseKiteParams:    () => ({ min: 4, max: 18, dirs: [], daylight: true }),
+    SHORE_BEARINGS:     36,
+    SHORE_SEA_THRESH:   0.5,
+    updateShoreStatusUI: () => {},
+    drawShoreCompass:   null,
+    analyseShore:       () => {},
+    drawShoreDebug:     () => {},
+  });
+
+  vm.runInContext(APP_SRC, ctx);
+
+  return { ctx, cityInput, mockLocalStorage, geoCalls, replaceStateCalls };
+}
+
+// ── decideInitialLocation unit tests ─────────────────────────────────────────
+
+describe('decideInitialLocation', () => {
+  // Load app once; we'll call ctx.decideInitialLocation() directly.
+  const { ctx } = loadApp();
+
+  it('returns qparam when q param is present', () => {
+    expect(ctx.decideInitialLocation('Oslo', '', null))
+      .toEqual({ type: 'qparam', value: 'Oslo' });
+  });
+
+  it('returns typed when typed input is present and no q param', () => {
+    expect(ctx.decideInitialLocation('', 'London', null))
+      .toEqual({ type: 'typed', value: 'London' });
+  });
+
+  it('returns saved when only localStorage has a city', () => {
+    expect(ctx.decideInitialLocation('', '', 'Paris'))
+      .toEqual({ type: 'saved', value: 'Paris' });
+  });
+
+  it('returns geolocation when nothing is available', () => {
+    expect(ctx.decideInitialLocation('', '', null))
+      .toEqual({ type: 'geolocation' });
+  });
+
+  it('q param takes priority over typed input', () => {
+    expect(ctx.decideInitialLocation('Oslo', 'London', 'Paris'))
+      .toEqual({ type: 'qparam', value: 'Oslo' });
+  });
+
+  it('typed input takes priority over saved city', () => {
+    expect(ctx.decideInitialLocation('', 'London', 'Paris'))
+      .toEqual({ type: 'typed', value: 'London' });
+  });
+});
+
+// ── initialLoad integration tests ────────────────────────────────────────────
+
+describe('initialLoad – location source selection', () => {
+  it('uses q param from URL and populates city input', () => {
+    const { cityInput, geoCalls } = loadApp({ qParam: 'Copenhagen' });
+    expect(cityInput.value).toBe('Copenhagen');
+    expect(geoCalls).toHaveLength(0);
+  });
+
+  it('uses saved localStorage city and does not request geolocation', () => {
+    const { cityInput, geoCalls } = loadApp({ savedCity: 'Berlin', geoAvailable: true });
+    expect(cityInput.value).toBe('Berlin');
+    expect(geoCalls).toHaveLength(0);
+  });
+
+  it('updates the URL q param when using a saved city', () => {
+    const { replaceStateCalls } = loadApp({ savedCity: 'Vienna' });
+    expect(replaceStateCalls.length).toBeGreaterThan(0);
+    const lastUrl = replaceStateCalls.at(-1)[2];
+    expect(lastUrl).toContain('q=Vienna');
+  });
+
+  it('requests geolocation when no location source is available', () => {
+    const { geoCalls } = loadApp({ geoAvailable: true });
+    expect(geoCalls).toHaveLength(1);
+  });
+
+  it('q param takes priority over saved localStorage city', () => {
+    const { cityInput, geoCalls } = loadApp({ qParam: 'Oslo', savedCity: 'Berlin' });
+    expect(cityInput.value).toBe('Oslo');
+    expect(geoCalls).toHaveLength(0);
+  });
+});
+
+// ── loadAndSync persists city to localStorage ─────────────────────────────────
+
+describe('loadAndSync', () => {
+  it('saves the city to localStorage', () => {
+    const { ctx, mockLocalStorage } = loadApp();
+    ctx.loadAndSync('Lisbon', 'dmi_seamless');
+    expect(mockLocalStorage.store['vejr_city']).toBe('Lisbon');
+  });
+
+  it('overwrites a previously saved city', () => {
+    const { ctx, mockLocalStorage } = loadApp({ savedCity: 'Berlin' });
+    ctx.loadAndSync('Tokyo', 'dmi_seamless');
+    expect(mockLocalStorage.store['vejr_city']).toBe('Tokyo');
+  });
+
+  it('updates the URL q param', () => {
+    const { ctx, replaceStateCalls } = loadApp();
+    ctx.loadAndSync('Madrid', 'dmi_seamless');
+    const lastUrl = replaceStateCalls.at(-1)[2];
+    expect(lastUrl).toContain('q=Madrid');
+  });
+});


### PR DESCRIPTION
## Summary
This change adds persistent storage of the user's last searched city, allowing the app to restore it on subsequent visits when no explicit search is performed.

## Key Changes
- **Save city on search**: When a user searches for a city via `loadAndSync()`, the city name is now stored in `localStorage` under the key `vejr_city`
- **Restore city on load**: When the app initializes without a query parameter and geolocation is not available, it now checks for a previously saved city in localStorage and loads it instead of immediately attempting geolocation
- **Fallback behavior**: If no saved city exists, the app falls back to the original geolocation behavior

## Implementation Details
- The localStorage key `vejr_city` stores the city name as a string
- City restoration occurs in the initialization logic, setting both the input field value and loading the weather data
- This provides a better user experience by remembering the user's last location preference without requiring geolocation permissions

https://claude.ai/code/session_01LWmXnTuDEF9tUq1re8NUgw