### PR TITLE
Move build number into forecast header bar

### DIFF
--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
 
 const ROOT    = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const HTML_SRC = readFileSync(resolve(ROOT, 'vejr.html'), 'utf8');
 const APP_SRC = readFileSync(resolve(ROOT, 'app.js'), 'utf8');
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -194,5 +195,23 @@ describe('loadAndSync', () => {
     ctx.loadAndSync('Madrid', 'dmi_seamless');
     const lastUrl = replaceStateCalls.at(-1)[2];
     expect(lastUrl).toContain('q=Madrid');
+  });
+});
+
+// ── HTML structure ────────────────────────────────────────────────────────────
+
+describe('vejr.html structure', () => {
+  it('build-number is inside header-right', () => {
+    const headerRightMatch = HTML_SRC.match(/<div id="header-right"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/);
+    expect(headerRightMatch).not.toBeNull();
+    expect(headerRightMatch[0]).toContain('id="build-number"');
+  });
+
+  it('build-number does not appear as a standalone element outside the header', () => {
+    // The build-number div should not appear at the top level outside #header
+    // i.e. it should not follow </div> <!-- #rotator --> or the radar section directly
+    const afterRadar = HTML_SRC.split('</div> <!-- #rotator -->')[0];
+    const standalonePattern = /<div id="build-number"[^>]*>[^<]*<\/div>\s*\n\s*<\/div>\s*<!--\s*#rotator/;
+    expect(standalonePattern.test(HTML_SRC)).toBe(false);
   });
 });

--- a/vejr.html
+++ b/vejr.html
@@ -74,6 +74,7 @@
         <div id="updated-text">—</div>
         <div id="ens-status" style="font-size:10px;margin-top:3px;color:#778;">Ensemble: loading…</div>
         <div id="shore-status" style="font-size:10px;margin-top:3px;color:#778;"></div>
+        <div id="build-number" style="font-size:9px;color:#aaa;letter-spacing:0.5px;margin-top:3px;">build %%BUILD_NUMBER%%</div>
       </div>
     </div>
 
@@ -139,8 +140,6 @@
     <button class="radar-zoom-btn" id="radar-zoom-out" title="Zoom out">−</button>
   </div>
 </div>
-
-<div id="build-number" style="width:100%;text-align:right;font-size:9px;color:#aaa;letter-spacing:0.5px;margin-top:6px;">build %%BUILD_NUMBER%%</div>
 
 </div> <!-- #rotator -->
 


### PR DESCRIPTION
Relocates the build number display from a standalone element below the
radar section into the header-right div, so it appears alongside the
updated-text and status fields in the forecast header bar.

https://claude.ai/code/session_01UpLj34H1bnCGnBQcnd8iAo