### PR TITLE
Add branch name to dev build number

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Generate build number
         id: build
         run: |
-          BUILD=$(date -u '+%Y.%m.%d')-${{ github.run_number }}-dev
+          BRANCH=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          BUILD=$(date -u '+%Y.%m.%d')-${{ github.run_number }}-${BRANCH}
           echo "number=$BUILD" >> $GITHUB_OUTPUT
 
       - name: Checkout


### PR DESCRIPTION
Build numbers for dev deploys now include the branch name, e.g.
`2026.04.02-42-my-feature-branch`, instead of the generic `-dev` suffix.
Branch name is sanitized to replace non-alphanumeric characters with `-`.

https://claude.ai/code/session_01VE9bTo7jcayiX56gWnh1QJ