### PR TITLE
Mobile usability: safe-area insets + portrait 36h forecast

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,7 +142,7 @@ async function load(cityName, model) {
       ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
     };
     // Double rAF ensures layout is complete before measuring canvas width
-    requestAnimationFrame(() => requestAnimationFrame(() => renderAll(lastData)));
+    requestAnimationFrame(() => requestAnimationFrame(() => renderDisplay(lastData)));
     // Load RainViewer radar centred on the selected city
     if (window.loadRadar) window.loadRadar(loc.latitude, loc.longitude);
     // Store coords for on-demand shore analysis (triggered from the kite modal)
@@ -154,6 +154,36 @@ async function load(cityName, model) {
     document.getElementById('error-msg').style.display='block';
   }
 }
+/* ══════════════════════════════════════════════════
+   PORTRAIT-AWARE RENDERING
+   In portrait mode only the first 36 h are shown.
+══════════════════════════════════════════════════ */
+function slicePercentiles(obj, n) {
+  if (!obj) return null;
+  return { p10: obj.p10.slice(0, n), p50: obj.p50.slice(0, n), p90: obj.p90.slice(0, n) };
+}
+
+function renderDisplay(d) {
+  const portrait = window.matchMedia('(orientation: portrait)').matches;
+  const hours = portrait ? 36 : FORECAST_DAYS * 24;
+  const n3h = Math.ceil(hours / STEP);
+  const n1h = Math.ceil(hours / STEP1H);
+  const s = {
+    times:    d.times.slice(0, n3h),    temps:    d.temps.slice(0, n3h),
+    precips:  d.precips.slice(0, n3h),  gusts:    d.gusts.slice(0, n3h),
+    winds:    d.winds.slice(0, n3h),    dirs:     d.dirs.slice(0, n3h),
+    codes:    d.codes.slice(0, n3h),
+    ensTemp:  slicePercentiles(d.ensTemp,  n3h), ensWind:  slicePercentiles(d.ensWind,  n3h),
+    ensGust:  slicePercentiles(d.ensGust,  n3h), ensPrecip: slicePercentiles(d.ensPrecip, n3h),
+    times1h:  d.times1h.slice(0, n1h),  temps1h:  d.temps1h.slice(0, n1h),
+    precips1h: d.precips1h.slice(0, n1h), gusts1h: d.gusts1h.slice(0, n1h),
+    winds1h:  d.winds1h.slice(0, n1h),
+    ensTemp1h:  slicePercentiles(d.ensTemp1h,  n1h), ensWind1h:  slicePercentiles(d.ensWind1h,  n1h),
+    ensGust1h:  slicePercentiles(d.ensGust1h,  n1h), ensPrecip1h: slicePercentiles(d.ensPrecip1h, n1h),
+  };
+  renderAll(s);
+}
+
 /* ══════════════════════════════════════════════════
    HOVER CROSSHAIR + TOOLTIP
 ══════════════════════════════════════════════════ */
@@ -330,10 +360,9 @@ function attachHoverListeners() {
     if (!lastData) return;
     const wrap = e.target.closest('.chart-canvas-wrap');
     if (!wrap) { hideTooltip(); return; }
-    const rect     = wrap.getBoundingClientRect();
-    const portrait = window.matchMedia('(orientation: portrait)').matches;
-    const relX     = portrait ? (e.clientY - rect.top) : (e.clientX - rect.left);
-    const span     = portrait ? rect.height : rect.width;
+    const rect  = wrap.getBoundingClientRect();
+    const relX  = e.clientX - rect.left;
+    const span  = rect.width;
     const fracX    = Math.max(0, Math.min(1, relX / span));
     const n1h      = lastData.times1h.length;
     const n3h      = lastData.times.length;
@@ -789,7 +818,7 @@ function renderShoreDebug() {
     const cfg = readDialogConfig();
     setKiteParams(cfg);
     overlay.classList.remove('open');
-    if (lastData) renderAll(lastData);
+    if (lastData) renderDisplay(lastData);
   });
 
   shoreFetchBtn.addEventListener('click', () => {
@@ -816,7 +845,7 @@ function renderShoreDebug() {
       }
       updateShoreStatusUI();
       drawModalCompass();
-      if (lastData) renderAll(lastData);
+      if (lastData) renderDisplay(lastData);
       shoreFetchBtn.disabled    = false;
       shoreFetchBtn.textContent = '🌊 Fetch sea bearings';
     });
@@ -970,7 +999,7 @@ async function loadAtCoords(lat, lon, model) {
       times1h, temps1h, precips1h, gusts1h, winds1h,
       ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
     };
-    requestAnimationFrame(() => requestAnimationFrame(() => renderAll(lastData)));
+    requestAnimationFrame(() => requestAnimationFrame(() => renderDisplay(lastData)));
     // ── Do NOT call loadRadar here – radar map position is already correct ──
     lastShoreCoords = { lat, lon };
     updateShoreStatusUI();
@@ -1034,7 +1063,7 @@ document.getElementById('model-select').addEventListener('change', () => {
 let resizeTimer;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(() => { if (lastData) renderAll(lastData); }, 100);
+  resizeTimer = setTimeout(() => { if (lastData) renderDisplay(lastData); }, 100);
 });
 // ── Radar pin drag → update location ────────────────────────────────────
 if (window.setRadarDragCallback) {

--- a/app.js
+++ b/app.js
@@ -158,9 +158,9 @@ async function load(cityName, model) {
    PORTRAIT-AWARE RENDERING
    In portrait mode only the first 36 h are shown.
 ══════════════════════════════════════════════════ */
-function slicePercentiles(obj, n) {
+function slicePercentilesFrom(obj, start, n) {
   if (!obj) return null;
-  return { p10: obj.p10.slice(0, n), p50: obj.p50.slice(0, n), p90: obj.p90.slice(0, n) };
+  return { p10: obj.p10.slice(start, start + n), p50: obj.p50.slice(start, start + n), p90: obj.p90.slice(start, start + n) };
 }
 
 function renderDisplay(d) {
@@ -168,18 +168,27 @@ function renderDisplay(d) {
   const hours = portrait ? 36 : FORECAST_DAYS * 24;
   const n3h = Math.ceil(hours / STEP);
   const n1h = Math.ceil(hours / STEP1H);
+  // In portrait, start from the current time rather than midnight.
+  let s3 = 0, s1 = 0;
+  if (portrait) {
+    const now = Date.now();
+    const i = d.times.findIndex(t => new Date(t).getTime() >= now);
+    s3 = i >= 0 ? i : 0;
+    const i1 = d.times1h.findIndex(t => new Date(t).getTime() >= now);
+    s1 = i1 >= 0 ? i1 : 0;
+  }
   const s = {
-    times:    d.times.slice(0, n3h),    temps:    d.temps.slice(0, n3h),
-    precips:  d.precips.slice(0, n3h),  gusts:    d.gusts.slice(0, n3h),
-    winds:    d.winds.slice(0, n3h),    dirs:     d.dirs.slice(0, n3h),
-    codes:    d.codes.slice(0, n3h),
-    ensTemp:  slicePercentiles(d.ensTemp,  n3h), ensWind:  slicePercentiles(d.ensWind,  n3h),
-    ensGust:  slicePercentiles(d.ensGust,  n3h), ensPrecip: slicePercentiles(d.ensPrecip, n3h),
-    times1h:  d.times1h.slice(0, n1h),  temps1h:  d.temps1h.slice(0, n1h),
-    precips1h: d.precips1h.slice(0, n1h), gusts1h: d.gusts1h.slice(0, n1h),
-    winds1h:  d.winds1h.slice(0, n1h),
-    ensTemp1h:  slicePercentiles(d.ensTemp1h,  n1h), ensWind1h:  slicePercentiles(d.ensWind1h,  n1h),
-    ensGust1h:  slicePercentiles(d.ensGust1h,  n1h), ensPrecip1h: slicePercentiles(d.ensPrecip1h, n1h),
+    times:    d.times.slice(s3, s3 + n3h),    temps:    d.temps.slice(s3, s3 + n3h),
+    precips:  d.precips.slice(s3, s3 + n3h),  gusts:    d.gusts.slice(s3, s3 + n3h),
+    winds:    d.winds.slice(s3, s3 + n3h),    dirs:     d.dirs.slice(s3, s3 + n3h),
+    codes:    d.codes.slice(s3, s3 + n3h),
+    ensTemp:  slicePercentilesFrom(d.ensTemp,  s3, n3h), ensWind:  slicePercentilesFrom(d.ensWind,  s3, n3h),
+    ensGust:  slicePercentilesFrom(d.ensGust,  s3, n3h), ensPrecip: slicePercentilesFrom(d.ensPrecip, s3, n3h),
+    times1h:  d.times1h.slice(s1, s1 + n1h),  temps1h:  d.temps1h.slice(s1, s1 + n1h),
+    precips1h: d.precips1h.slice(s1, s1 + n1h), gusts1h: d.gusts1h.slice(s1, s1 + n1h),
+    winds1h:  d.winds1h.slice(s1, s1 + n1h),
+    ensTemp1h:  slicePercentilesFrom(d.ensTemp1h,  s1, n1h), ensWind1h:  slicePercentilesFrom(d.ensWind1h,  s1, n1h),
+    ensGust1h:  slicePercentilesFrom(d.ensGust1h,  s1, n1h), ensPrecip1h: slicePercentilesFrom(d.ensPrecip1h, s1, n1h),
   };
   renderAll(s);
 }

--- a/radar.js
+++ b/radar.js
@@ -24,9 +24,8 @@
   const zoomIn    = document.getElementById('radar-zoom-in');
   const zoomOut   = document.getElementById('radar-zoom-out');
 
-  // ── Rotation-aware drag ────────────────────────────────────────────────
+  // ── Map drag ──────────────────────────────────────────────────────────
   function attachMapDrag(mapEl) {
-    const isPortrait = () => window.matchMedia('(orientation: portrait)').matches;
     let dragging = false, lastX = 0, lastY = 0;
     function isMarkerTarget(e) {
       return e.target && e.target.closest && e.target.closest('.radar-loc-wrap');
@@ -36,8 +35,7 @@
       if (!dragging || !radarMap || markerDragging) return;
       const dx = x - lastX, dy = y - lastY;
       lastX = x; lastY = y;
-      if (isPortrait()) radarMap.panBy([-dy,  dx], { animate: false });
-      else              radarMap.panBy([-dx, -dy], { animate: false });
+      radarMap.panBy([-dx, -dy], { animate: false });
     }
     function onEnd() { dragging = false; }
     mapEl.addEventListener('touchstart',  e => { if (isMarkerTarget(e)) return; e.preventDefault(); onStart(e.touches[0].clientX, e.touches[0].clientY); }, { passive: false });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -27,8 +27,10 @@ function makeEl(value = '') {
  * @param {string}  opts.qParam       – value of the `q` URL parameter (default: none)
  * @param {string|null} opts.savedCity – value stored in localStorage under 'vejr_city'
  * @param {boolean} opts.geoAvailable – whether navigator.geolocation is present
+ * @param {boolean} opts.portrait     – simulate portrait orientation (default: false)
+ * @param {Function|null} opts.renderAllSpy – optional spy to replace the renderAll stub
  */
-function loadApp({ qParam = '', savedCity = null, geoAvailable = false } = {}) {
+function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait = false, renderAllSpy = null } = {}) {
   const cityInput        = makeEl();
   const geoCalls         = [];
   const replaceStateCalls = [];
@@ -53,6 +55,10 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false } = {}) {
       SHORE_STATUS:         { state: 'idle', msg: '' },
       SHORE_DEBUG:          null,
       devicePixelRatio:     1,
+      matchMedia: (q) => ({
+        matches: q === '(orientation: portrait)' ? portrait : false,
+        addEventListener: () => {},
+      }),
     },
     document: {
       getElementById: (id) => {
@@ -82,11 +88,12 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false } = {}) {
     fetchWeather:       () => new Promise(() => {}),
     fetchEnsemble:      () => new Promise(() => {}),
     ensemblePercentiles: () => null,
-    renderAll:          () => {},
+    renderAll:          renderAllSpy || (() => {}),
     isKiteOptimal:      () => false,
     snapBearing:        (d) => d,
     FORECAST_DAYS:      7,
     STEP:               3,
+    STEP1H:             1,
     KITE_DEFAULTS:      { min: 4, max: 18, dirs: [], daylight: true },
     KITE_CFG:           { min: 4, max: 18, dirs: [], daylight: true },
     setKiteParams:      () => {},
@@ -210,8 +217,66 @@ describe('vejr.html structure', () => {
   it('build-number does not appear as a standalone element outside the header', () => {
     // The build-number div should not appear at the top level outside #header
     // i.e. it should not follow </div> <!-- #rotator --> or the radar section directly
-    const afterRadar = HTML_SRC.split('</div> <!-- #rotator -->')[0];
     const standalonePattern = /<div id="build-number"[^>]*>[^<]*<\/div>\s*\n\s*<\/div>\s*<!--\s*#rotator/;
     expect(standalonePattern.test(HTML_SRC)).toBe(false);
+  });
+});
+
+// ── renderDisplay slicing ─────────────────────────────────────────────────────
+
+/** Build a minimal lastData-shaped object with arrays of the given lengths. */
+function makeData(n3h, n1h) {
+  const arr3 = () => Array(n3h).fill(0);
+  const arr1 = () => Array(n1h).fill(0);
+  const pct3 = () => ({ p10: arr3(), p50: arr3(), p90: arr3() });
+  const pct1 = () => ({ p10: arr1(), p50: arr1(), p90: arr1() });
+  return {
+    times: arr3(), temps: arr3(), precips: arr3(),
+    gusts: arr3(), winds: arr3(), dirs: arr3(), codes: arr3(),
+    ensTemp: pct3(), ensWind: pct3(), ensGust: pct3(), ensPrecip: pct3(),
+    times1h: arr1(), temps1h: arr1(), precips1h: arr1(),
+    gusts1h: arr1(), winds1h: arr1(),
+    ensTemp1h: pct1(), ensWind1h: pct1(), ensGust1h: pct1(), ensPrecip1h: pct1(),
+  };
+}
+
+describe('renderDisplay slicing', () => {
+  const TOTAL_3H = (7 * 24) / 3;   // 56 — full 7-day dataset at 3-hour step
+  const TOTAL_1H = 7 * 24;         // 168
+
+  it('slices to 36 h in portrait mode (12×3h entries, 36×1h entries)', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(calls).toHaveLength(1);
+    expect(calls[0].times).toHaveLength(12);     // 36 / 3
+    expect(calls[0].times1h).toHaveLength(36);   // 36 / 1
+  });
+
+  it('slices ensemble percentile arrays to match 36 h in portrait mode', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(calls[0].ensTemp.p10).toHaveLength(12);
+    expect(calls[0].ensTemp1h.p50).toHaveLength(36);
+  });
+
+  it('keeps full 7-day data in landscape mode (56×3h entries, 168×1h entries)', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: false, renderAllSpy: (d) => calls.push(d) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(calls).toHaveLength(1);
+    expect(calls[0].times).toHaveLength(56);
+    expect(calls[0].times1h).toHaveLength(168);
+  });
+
+  it('handles null ensemble data without throwing', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
+    const d = makeData(TOTAL_3H, TOTAL_1H);
+    d.ensTemp = null; d.ensTemp1h = null;
+    expect(() => ctx.renderDisplay(d)).not.toThrow();
+    expect(calls[0].ensTemp).toBeNull();
+    expect(calls[0].ensTemp1h).toBeNull();
   });
 });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -224,18 +224,27 @@ describe('vejr.html structure', () => {
 
 // ── renderDisplay slicing ─────────────────────────────────────────────────────
 
-/** Build a minimal lastData-shaped object with arrays of the given lengths. */
-function makeData(n3h, n1h) {
-  const arr3 = () => Array(n3h).fill(0);
-  const arr1 = () => Array(n1h).fill(0);
-  const pct3 = () => ({ p10: arr3(), p50: arr3(), p90: arr3() });
-  const pct1 = () => ({ p10: arr1(), p50: arr1(), p90: arr1() });
+/**
+ * Build a minimal lastData-shaped object.
+ * @param {number} n3h  – total entries in 3-hour arrays
+ * @param {number} n1h  – total entries in 1-hour arrays
+ * @param {Date}   base – timestamp of the first entry (default: 2 days ago so "now" falls in the middle)
+ */
+function makeData(n3h, n1h, base = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)) {
+  const iso3 = (i) => new Date(base.getTime() + i * 3 * 60 * 60 * 1000).toISOString();
+  const iso1 = (i) => new Date(base.getTime() + i *     60 * 60 * 1000).toISOString();
+  const arr3 = () => Array.from({ length: n3h }, (_, i) => iso3(i));
+  const arr1 = () => Array.from({ length: n1h }, (_, i) => iso1(i));
+  const num3 = () => Array(n3h).fill(0);
+  const num1 = () => Array(n1h).fill(0);
+  const pct3 = () => ({ p10: num3(), p50: num3(), p90: num3() });
+  const pct1 = () => ({ p10: num1(), p50: num1(), p90: num1() });
   return {
-    times: arr3(), temps: arr3(), precips: arr3(),
-    gusts: arr3(), winds: arr3(), dirs: arr3(), codes: arr3(),
+    times: arr3(), temps: num3(), precips: num3(),
+    gusts: num3(), winds: num3(), dirs: num3(), codes: num3(),
     ensTemp: pct3(), ensWind: pct3(), ensGust: pct3(), ensPrecip: pct3(),
-    times1h: arr1(), temps1h: arr1(), precips1h: arr1(),
-    gusts1h: arr1(), winds1h: arr1(),
+    times1h: arr1(), temps1h: num1(), precips1h: num1(),
+    gusts1h: num1(), winds1h: num1(),
     ensTemp1h: pct1(), ensWind1h: pct1(), ensGust1h: pct1(), ensPrecip1h: pct1(),
   };
 }
@@ -251,6 +260,16 @@ describe('renderDisplay slicing', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].times).toHaveLength(12);     // 36 / 3
     expect(calls[0].times1h).toHaveLength(36);   // 36 / 1
+  });
+
+  it('starts from current time, not midnight, in portrait mode', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
+    const d = makeData(TOTAL_3H, TOTAL_1H);
+    ctx.renderDisplay(d);
+    // First rendered timestamp should be >= now (within one 3h slot)
+    const firstTime = new Date(calls[0].times[0]).getTime();
+    expect(firstTime).toBeGreaterThanOrEqual(Date.now() - 3 * 60 * 60 * 1000);
   });
 
   it('slices ensemble percentile arrays to match 36 h in portrait mode', () => {

--- a/vejr.css
+++ b/vejr.css
@@ -1,28 +1,9 @@
-/* ── Portrait rotation ─────────────────────────────────────────────────────
-   In portrait mode the #rotator div is fixed to the viewport, rotated 90°
-   and sized to exactly fill the screen (width↔height swapped).
-──────────────────────────────────────────────────────────────────────────── */
 #rotator {
   width: 100%;
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
-}
-
-@media (orientation: portrait) {
-  html, body { overflow: hidden; width: 100%; height: 100%; }
-  #rotator {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vh;   /* rotated: logical width = viewport height */
-    height: 100vw;  /* rotated: logical height = viewport width  */
-    transform-origin: top left;
-    transform: rotate(90deg) translateX(0) translateY(-100%);
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -37,7 +18,10 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 8px;
+  padding: max(8px, env(safe-area-inset-top))
+           max(8px, env(safe-area-inset-right))
+           max(8px, env(safe-area-inset-bottom))
+           max(8px, env(safe-area-inset-left));
 }
 #search-bar {
   display: flex;
@@ -178,8 +162,8 @@ canvas.main-canvas {
   display: none;
   position: fixed;
   z-index: 1000;
-  bottom: 10px;
-  right: 10px;
+  bottom: max(10px, calc(env(safe-area-inset-bottom) + 4px));
+  right:  max(10px, calc(env(safe-area-inset-right)  + 4px));
   background: rgba(18, 26, 38, 0.93);
   border: 1px solid rgba(120,160,200,0.35);
   border-radius: 6px;

--- a/vejr.html
+++ b/vejr.html
@@ -35,7 +35,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="vejr.css?v=20">
+<link rel="stylesheet" href="vejr.css?v=21">
 </head>
 <body>
 <div id="rotator">
@@ -224,12 +224,12 @@
 </div>
 
 <!-- ── Scripts (order matters: config → api → icons → charts → radar → app) ── -->
-<script src="config.js?v=20"></script>
-<script src="api.js?v=20"></script>
-<script src="weather-icons.js?v=20"></script>
-<script src="charts.js?v=20"></script>
-<script src="radar.js?v=20"></script>
-<script src="shore.js?v=20"></script>
-<script src="app.js?v=20"></script>
+<script src="config.js?v=21"></script>
+<script src="api.js?v=21"></script>
+<script src="weather-icons.js?v=21"></script>
+<script src="charts.js?v=21"></script>
+<script src="radar.js?v=21"></script>
+<script src="shore.js?v=21"></script>
+<script src="app.js?v=21"></script>
 </body>
 </html>

--- a/vejr.html
+++ b/vejr.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">


### PR DESCRIPTION
- Remove CSS 90° rotation in portrait mode; the app now displays
  natively in portrait without forcing landscape orientation.
- In portrait mode, renderDisplay() slices data to the first 36 hours
  so the chart isn't overwhelmed on a narrow screen. Landscape keeps
  the full 7-day view. Orientation changes re-render automatically via
  the existing resize debounce.
- Add viewport-fit=cover and env(safe-area-inset-*) padding on body
  and the hover tooltip so buttons/cards stay clear of notch/gesture
  edge zones on modern phones.
- Remove portrait-specific coordinate swaps in hover listeners and
  radar map drag handler (no longer needed without rotation).
- Add matchMedia mock + STEP1H constant to test context; add 4 new
  tests covering renderDisplay() slicing in both orientations.

https://claude.ai/code/session_01R1j84mZS7DzhMsPoCTyr3J