### PR TITLE
Remove redundant Show weather button

### DIFF
--- a/app.js
+++ b/app.js
@@ -1058,12 +1058,8 @@ async function loadAndSync(city, model) {
   localStorage.setItem('vejr_city', city);
   await load(city, model);
 }
-document.getElementById('search-btn').addEventListener('click', () => {
-  const v = document.getElementById('city-input').value.trim();
-  if (v) loadAndSync(v, getModel());
-});
 document.getElementById('city-input').addEventListener('keydown', e => {
-  if (e.key === 'Enter') document.getElementById('search-btn').click();
+  if (e.key === 'Enter') { const v = e.target.value.trim(); if (v) loadAndSync(v, getModel()); }
 });
 document.getElementById('model-select').addEventListener('change', () => {
   const v = document.getElementById('city-input').value.trim();

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -214,6 +214,10 @@ describe('vejr.html structure', () => {
     expect(headerRightMatch[0]).toContain('id="build-number"');
   });
 
+  it('does not contain a search-btn button', () => {
+    expect(HTML_SRC).not.toContain('id="search-btn"');
+  });
+
   it('build-number does not appear as a standalone element outside the header', () => {
     // The build-number div should not appear at the top level outside #header
     // i.e. it should not follow </div> <!-- #rotator --> or the radar section directly

--- a/vejr.css
+++ b/vejr.css
@@ -39,19 +39,6 @@ body {
   outline: none;
 }
 #city-input:focus { border-color: #003c8f; }
-#search-btn {
-  padding: 8px 20px;
-  background: #003c8f;
-  color: #fff;
-  border: none;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  letter-spacing: 0.5px;
-  white-space: nowrap;
-}
-#search-btn:hover { background: #0051c4; }
 #model-select {
   padding: 8px 10px;
   font-family: 'IBM Plex Sans', sans-serif;

--- a/vejr.html
+++ b/vejr.html
@@ -52,8 +52,7 @@
     <option value="meteofrance_seamless">Météo-France</option>
     <option value="gfs_seamless">NOAA GFS</option>
   </select>
-  <button id="search-btn">Show weather</button>
-  <button id="kite-cfg-btn" title="Kitesurfing settings">⚙ 🪁</button>
+<button id="kite-cfg-btn" title="Kitesurfing settings">⚙ 🪁</button>
 </div>
 
 <div id="forecast-container">


### PR DESCRIPTION
The button duplicated functionality already provided by pressing Enter
in the city input. Remove the button element, its click handler, and
CSS styles. Update the keydown handler to call loadAndSync directly.

https://claude.ai/code/session_01JPuph7Lss3KbTGojCrNEsi