### PR TITLE
Persist kite settings to localStorage so they survive iOS Home Screen launches

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,6 +11,8 @@ const DA_MON   = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','N
 /* ══════════════════════════════════════════════════
    KITE CONFIG  (read from URL, defaults if absent)
    URL params: kite_min, kite_max, kite_dirs (comma-separated degrees, snapped to 10°)
+   Settings are also mirrored to localStorage so they survive iOS Home Screen launches,
+   where the shortcut always opens the original saved URL (without any replaceState changes).
 ══════════════════════════════════════════════════ */
 const KITE_DEFAULTS = {
   min:  7,
@@ -18,6 +20,7 @@ const KITE_DEFAULTS = {
   dirs: [90, 270],   // exact bearings (snapped to nearest 10°)
   daylight: true,
 };
+const KITE_STORAGE_KEY = 'vejr_kite_cfg';
 
 /** Snap any bearing to the nearest 10° slot (0, 10, 20 … 350). */
 function snapBearing(deg) {
@@ -27,10 +30,28 @@ function snapBearing(deg) {
 function parseKiteParams() {
   const p = new URLSearchParams(window.location.search);
   const cfg = { ...KITE_DEFAULTS };
-  if (p.has('kite_min'))  cfg.min  = parseFloat(p.get('kite_min'))  || cfg.min;
-  if (p.has('kite_max'))  cfg.max  = parseFloat(p.get('kite_max'))  || cfg.max;
-  if (p.has('kite_dirs')) cfg.dirs = p.get('kite_dirs').split(',').map(Number).filter(v => !isNaN(v)).map(snapBearing);
-  if (p.has('kite_at_night')) cfg.daylight = p.get('kite_at_night') !== '0' ? false : true;
+  const hasUrlParams = p.has('kite_min') || p.has('kite_max') || p.has('kite_dirs') || p.has('kite_at_night');
+
+  if (hasUrlParams) {
+    if (p.has('kite_min'))  cfg.min  = parseFloat(p.get('kite_min'))  || cfg.min;
+    if (p.has('kite_max'))  cfg.max  = parseFloat(p.get('kite_max'))  || cfg.max;
+    if (p.has('kite_dirs')) cfg.dirs = p.get('kite_dirs').split(',').map(Number).filter(v => !isNaN(v)).map(snapBearing);
+    if (p.has('kite_at_night')) cfg.daylight = p.get('kite_at_night') !== '0' ? false : true;
+    // Persist URL-provided settings so they survive future Home Screen launches
+    try { localStorage.setItem(KITE_STORAGE_KEY, JSON.stringify(cfg)); } catch(_) {}
+  } else {
+    // No URL params — fall back to localStorage (used when launched from iOS Home Screen)
+    try {
+      const stored = localStorage.getItem(KITE_STORAGE_KEY);
+      if (stored) {
+        const saved = JSON.parse(stored);
+        if (typeof saved.min     === 'number')  cfg.min     = saved.min;
+        if (typeof saved.max     === 'number')  cfg.max     = saved.max;
+        if (Array.isArray(saved.dirs))          cfg.dirs    = saved.dirs;
+        if (typeof saved.daylight === 'boolean') cfg.daylight = saved.daylight;
+      }
+    } catch(_) { /* ignore corrupt storage */ }
+  }
   return cfg;
 }
 
@@ -38,6 +59,8 @@ let KITE_CFG = parseKiteParams();
 
 function setKiteParams(cfg) {
   KITE_CFG = cfg;
+  // Persist to localStorage so settings survive iOS Home Screen launches
+  try { localStorage.setItem(KITE_STORAGE_KEY, JSON.stringify(cfg)); } catch(_) {}
   const url = new URL(window.location.href);
   const def = KITE_DEFAULTS;
   if (cfg.min  !== def.min)  url.searchParams.set('kite_min',  cfg.min);  else url.searchParams.delete('kite_min');

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { loadScripts } from './helpers/loader.js';
 
-const { snapBearing } = loadScripts('config.js');
-
 describe('snapBearing', () => {
+  const { snapBearing } = loadScripts('config.js');
+
   it('returns 0 for 0°', () => {
     expect(snapBearing(0)).toBe(0);
   });
@@ -32,5 +32,81 @@ describe('snapBearing', () => {
   it('handles values above 360', () => {
     expect(snapBearing(370)).toBe(10);
     expect(snapBearing(720)).toBe(0);
+  });
+});
+
+describe('kite settings – localStorage persistence (iOS Home Screen fix)', () => {
+  it('returns defaults when no URL params and localStorage is empty', () => {
+    const ctx = loadScripts('config.js');
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.min).toBe(7);
+    expect(cfg.max).toBe(9);
+    expect(cfg.dirs).toEqual([90, 270]);
+    expect(cfg.daylight).toBe(true);
+  });
+
+  it('parseKiteParams reads from localStorage when no URL params are present', () => {
+    const ctx = loadScripts('config.js');
+    ctx.localStorage.setItem('vejr_kite_cfg', JSON.stringify({ min: 5, max: 11, dirs: [180], daylight: false }));
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.min).toBe(5);
+    expect(cfg.max).toBe(11);
+    expect(cfg.dirs).toEqual([180]);
+    expect(cfg.daylight).toBe(false);
+  });
+
+  it('URL params take priority over localStorage', () => {
+    const ctx = loadScripts('config.js');
+    ctx.localStorage.setItem('vejr_kite_cfg', JSON.stringify({ min: 5, max: 11, dirs: [180], daylight: false }));
+    ctx.window.location.search = '?kite_min=8&kite_max=12';
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.min).toBe(8);
+    expect(cfg.max).toBe(12);
+  });
+
+  it('parseKiteParams saves URL-provided settings to localStorage', () => {
+    const ctx = loadScripts('config.js');
+    ctx.window.location.search = '?kite_min=6&kite_max=10&kite_dirs=180,270';
+    ctx.parseKiteParams();
+    const stored = JSON.parse(ctx.localStorage.getItem('vejr_kite_cfg'));
+    expect(stored.min).toBe(6);
+    expect(stored.max).toBe(10);
+    expect(stored.dirs).toEqual([180, 270]);
+  });
+
+  it('setKiteParams saves settings to localStorage', () => {
+    const ctx = loadScripts('config.js');
+    ctx.setKiteParams({ min: 6, max: 10, dirs: [180], daylight: true });
+    const stored = JSON.parse(ctx.localStorage.getItem('vejr_kite_cfg'));
+    expect(stored.min).toBe(6);
+    expect(stored.max).toBe(10);
+    expect(stored.dirs).toEqual([180]);
+    expect(stored.daylight).toBe(true);
+  });
+
+  it('setKiteParams-saved settings are restored by parseKiteParams on next load', () => {
+    // Simulate: user changes settings → closes app → reopens from Home Screen (no URL params)
+    const ctx1 = loadScripts('config.js');
+    ctx1.setKiteParams({ min: 4, max: 8, dirs: [270], daylight: false });
+    const savedValue = ctx1.localStorage.getItem('vejr_kite_cfg');
+
+    // New "session" with the persisted value pre-loaded but no URL params
+    const ctx2 = loadScripts('config.js');
+    ctx2.localStorage.setItem('vejr_kite_cfg', savedValue);
+    const cfg = ctx2.parseKiteParams();
+    expect(cfg.min).toBe(4);
+    expect(cfg.max).toBe(8);
+    expect(cfg.dirs).toEqual([270]);
+    expect(cfg.daylight).toBe(false);
+  });
+
+  it('ignores corrupt localStorage data and returns defaults', () => {
+    const ctx = loadScripts('config.js');
+    ctx.localStorage.setItem('vejr_kite_cfg', 'not valid json {{{');
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.min).toBe(7);
+    expect(cfg.max).toBe(9);
+    expect(cfg.dirs).toEqual([90, 270]);
+    expect(cfg.daylight).toBe(true);
   });
 });

--- a/tests/helpers/loader.js
+++ b/tests/helpers/loader.js
@@ -23,15 +23,26 @@ export function loadScripts(...relPaths) {
     SHORE_DEBUG:  null,
   };
 
+  const mockLocalStorage = (() => {
+    const store = {};
+    return {
+      getItem:    (k)      => Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null,
+      setItem:    (k, v)   => { store[k] = String(v); },
+      removeItem: (k)      => { delete store[k]; },
+      clear:      ()       => { Object.keys(store).forEach(k => delete store[k]); },
+    };
+  })();
+
   const ctx = vm.createContext({
     window:             mockWindow,
+    localStorage:       mockLocalStorage,
     console,
     Math,
     Array, Float32Array, Set, Map,
     Number, String, Boolean, Object,
     parseInt, parseFloat, isNaN, isFinite,
     encodeURIComponent, decodeURIComponent,
-    URLSearchParams,
+    URL, URLSearchParams,
     Promise, Error,
     setTimeout, clearTimeout,
     fetch: () => Promise.reject(new Error('fetch not mocked in tests')),


### PR DESCRIPTION
When the app is added to the iOS Home Screen, the shortcut always opens
the original saved URL. Any setting changes made via history.replaceState()
are lost on the next Home Screen launch because the URL never changes.

Fix: mirror all kite settings (min/max wind, directions, daylight) to
localStorage in both parseKiteParams (when URL params are present) and
setKiteParams (on every change). On load, if no URL params are found,
fall back to localStorage — which is preserved across Home Screen sessions.

URL params still take priority, preserving the shareable-link behaviour.

https://claude.ai/code/session_01CVHT3JF2WcvWF8hyZTAiMb