### PR TITLE
Make sea-bearing estimation robust with closed coastline rings

### DIFF
--- a/shore.js
+++ b/shore.js
@@ -250,9 +250,21 @@ function clockwiseBboxPath(from, to, bbox) {
   const fromSnap = snapToBbox(from, bbox);
   const toSnap   = snapToBbox(to,   bbox);
 
-  const fromPos = cpos(fromSnap);
-  let   toPos   = cpos(toSnap);
-  if (toPos <= fromPos) toPos += 4.0;   // ensure strictly clockwise advance
+  const fromPos   = cpos(fromSnap);
+  const origToPos = cpos(toSnap);
+  let   toPos     = origToPos;
+
+  if (toPos <= fromPos) {
+    // The clockwise path would wrap past the origin.  If from and to land on
+    // the same bbox edge (same integer band of cpos), the chain forms a
+    // U-shape that enters and exits through one edge.  Going all the way
+    // around the perimeter in that case wrongly encloses the entire bbox as
+    // land; instead close directly along that edge (short path, no corners).
+    if (Math.floor(fromPos) === Math.floor(origToPos)) {
+      return [toSnap];
+    }
+    toPos += 4.0;   // different edges — proceed with full clockwise advance
+  }
 
   // Collect corners that fall in (fromPos, toPos), sorted by clockwise position.
   // We must sort by the shifted cp value — not by ci — because when fromPos > some

--- a/shore.js
+++ b/shore.js
@@ -174,6 +174,186 @@ function isLandByRayCross(lat, lon, coastWays, bbox, hasCoast) {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   COASTLINE STITCHING + BBOX CLOSURE
+   ──────────────────────────────────────────────────────────────────────────
+   OSM coastline ways fetched by Overpass are *partial* slices of the global
+   coastline ring.  When a continental coast enters our bbox from one side and
+   exits from another, the resulting open chain produces unmatched winding-
+   number crossings that misclassify sea points as land (or vice versa).
+   The fix is to:
+     1. Stitch connected ways into chains (matching shared endpoints).
+     2. Close every open chain by travelling clockwise around the bbox
+        boundary from the chain tail back to its head.
+   This turns the partial OSM data into properly-closed rings that the
+   winding-number algorithm can handle correctly.
+══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * Snap an arbitrary point to the nearest edge of the bounding box.
+ * Used to project open-chain endpoints onto the bbox boundary before closure.
+ */
+function snapToBbox(pt, bbox) {
+  const clampLat = lat => Math.max(bbox.s, Math.min(bbox.n, lat));
+  const clampLon = lon => Math.max(bbox.w, Math.min(bbox.e, lon));
+
+  const outsideLat = pt.lat > bbox.n || pt.lat < bbox.s;
+  const outsideLon = pt.lon > bbox.e || pt.lon < bbox.w;
+
+  // If the point is outside in exactly one axis, snap to that axis's edge —
+  // this avoids false ties when the point is near the corner in the other axis.
+  if (outsideLat && !outsideLon) {
+    return { lat: pt.lat > bbox.n ? bbox.n : bbox.s, lon: clampLon(pt.lon) };
+  }
+  if (outsideLon && !outsideLat) {
+    return { lat: clampLat(pt.lat), lon: pt.lon > bbox.e ? bbox.e : bbox.w };
+  }
+
+  // Outside in both axes (corner region) or already inside: use nearest edge.
+  const dE = Math.abs(pt.lon - bbox.e), dW = Math.abs(pt.lon - bbox.w);
+  const dN = Math.abs(pt.lat - bbox.n), dS = Math.abs(pt.lat - bbox.s);
+  const m  = Math.min(dE, dW, dN, dS);
+  if (m === dN) return { lat: bbox.n, lon: clampLon(pt.lon) };
+  if (m === dS) return { lat: bbox.s, lon: clampLon(pt.lon) };
+  if (m === dE) return { lat: clampLat(pt.lat), lon: bbox.e };
+  return                { lat: clampLat(pt.lat), lon: bbox.w };
+}
+
+/**
+ * Return the intermediate bbox corners plus the snapped `to` point needed to
+ * travel *clockwise* around the bbox boundary from `from` to `to`.
+ *
+ * Clockwise order (north-up): NE(0) → SE(1) → SW(2) → NW(3) → NE …
+ *
+ * Each boundary point is assigned a clockwise position cpos ∈ [0, 4):
+ *   East edge  (lon = bbox.e):  cpos = (bbox.n - lat) / (bbox.n - bbox.s)
+ *   South edge (lat = bbox.s):  cpos = 1 + (bbox.e - lon) / (bbox.e - bbox.w)
+ *   West edge  (lon = bbox.w):  cpos = 2 + (lat - bbox.s) / (bbox.n - bbox.s)
+ *   North edge (lat = bbox.n):  cpos = 3 + (lon - bbox.w) / (bbox.e - bbox.w)
+ */
+function clockwiseBboxPath(from, to, bbox) {
+  const { s, n, w, e } = bbox;
+  const CORNERS = [
+    { lat: n, lon: e },   // 0 = NE
+    { lat: s, lon: e },   // 1 = SE
+    { lat: s, lon: w },   // 2 = SW
+    { lat: n, lon: w },   // 3 = NW
+  ];
+  const TOL = 1e-5;
+
+  const cpos = pt => {
+    if (Math.abs(pt.lon - e) < TOL) return       (n - pt.lat) / (n - s);
+    if (Math.abs(pt.lat - s) < TOL) return 1.0 + (e - pt.lon) / (e - w);
+    if (Math.abs(pt.lon - w) < TOL) return 2.0 + (pt.lat - s) / (n - s);
+    return                                 3.0 + (pt.lon - w) / (e - w);
+  };
+
+  const fromSnap = snapToBbox(from, bbox);
+  const toSnap   = snapToBbox(to,   bbox);
+
+  const fromPos = cpos(fromSnap);
+  let   toPos   = cpos(toSnap);
+  if (toPos <= fromPos) toPos += 4.0;   // ensure strictly clockwise advance
+
+  const path = [];
+  for (let ci = 0; ci < 4; ci++) {
+    let cp = ci;
+    while (cp <= fromPos) cp += 4;       // shift corner into (fromPos, ...]
+    if (cp < toPos) path.push(CORNERS[ci]);
+  }
+  path.push(toSnap);
+  return path;
+}
+
+/**
+ * Stitch individual OSM coastline way-arrays into continuous chains by
+ * matching shared endpoints (within ENDPOINT_TOL degrees ≈ 1 m).
+ *
+ * Each way in `coastWays` is an array of {lat, lon} nodes.  Ways are
+ * reversed as needed when connected at their end rather than their start.
+ *
+ * Returns an array of chains (each an array of {lat, lon} nodes).
+ */
+function stitchCoastWays(coastWays) {
+  if (coastWays.length === 0) return [];
+
+  const ENDPOINT_TOL = 1e-5;
+  const ptKey = pt => `${pt.lat.toFixed(5)},${pt.lon.toFixed(5)}`;
+
+  // index: key → [{wayIdx, side: 'start'|'end'}]
+  const index = new Map();
+  const addToIndex = (pt, wayIdx, side) => {
+    const k = ptKey(pt);
+    if (!index.has(k)) index.set(k, []);
+    index.get(k).push({ wayIdx, side });
+  };
+  for (let i = 0; i < coastWays.length; i++) {
+    const w = coastWays[i];
+    addToIndex(w[0],          i, 'start');
+    addToIndex(w[w.length-1], i, 'end');
+  }
+
+  const used   = new Set();
+  const chains = [];
+
+  for (let i = 0; i < coastWays.length; i++) {
+    if (used.has(i)) continue;
+    used.add(i);
+    let chain = [...coastWays[i]];
+
+    // Extend forward from tail
+    for (;;) {
+      const k       = ptKey(chain[chain.length - 1]);
+      const matches = (index.get(k) || []).filter(m => !used.has(m.wayIdx));
+      if (!matches.length) break;
+      const { wayIdx, side } = matches[0];
+      used.add(wayIdx);
+      const w = coastWays[wayIdx];
+      chain = chain.concat(side === 'start' ? w.slice(1) : [...w].reverse().slice(1));
+    }
+
+    // Extend backward from head
+    for (;;) {
+      const k       = ptKey(chain[0]);
+      const matches = (index.get(k) || []).filter(m => !used.has(m.wayIdx));
+      if (!matches.length) break;
+      const { wayIdx, side } = matches[0];
+      used.add(wayIdx);
+      const w = coastWays[wayIdx];
+      chain = (side === 'end' ? w.slice(0, -1) : [...w].reverse().slice(0, -1)).concat(chain);
+    }
+
+    chains.push(chain);
+  }
+  return chains;
+}
+
+/**
+ * Stitch OSM coastline ways into chains, then close every open chain by
+ * appending a clockwise bbox-boundary path from the chain's tail back to
+ * its head.  Chains that are already closed (islands) are returned as-is.
+ *
+ * The clockwise closure ensures that the winding-number rule correctly
+ * classifies sea points even when only a partial coastal slice was fetched.
+ *
+ * @param {Array<Array<{lat,lon}>>} coastWays
+ * @param {{ s,n,w,e }}             bbox
+ * @returns {Array<Array<{lat,lon}>>}  closed rings
+ */
+function buildClosedCoastRings(coastWays, bbox) {
+  const TOL    = 1e-5;
+  const chains = stitchCoastWays(coastWays);
+  return chains.map(chain => {
+    const head = chain[0];
+    const tail = chain[chain.length - 1];
+    const closed =
+      Math.abs(head.lat - tail.lat) < TOL &&
+      Math.abs(head.lon - tail.lon) < TOL;
+    if (closed) return chain;
+    return chain.concat(clockwiseBboxPath(tail, head, bbox));
+  });
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
    OVERPASS QUERY BUILDER + FETCHER
 ══════════════════════════════════════════════════════════════════════════ */
 
@@ -302,9 +482,15 @@ async function analyseShore(lat, lon, onDone) {
 
     const hasCoastData = coastWays.length > 0;
 
+    // Stitch raw ways into chains and close open chains via the bbox boundary
+    // so that the winding-number algorithm always sees properly-closed rings.
+    const closedCoastRings = hasCoastData
+      ? buildClosedCoastRings(coastWays, bbox)
+      : [];
+
     // ── Origin classification (for debug / inland detection) ──
     const originInWater = waterPolys.some(p => pointInPoly(lat, lon, p));
-    const originIsLand  = isLandByRayCross(lat, lon, coastWays, bbox, hasCoastData);
+    const originIsLand  = isLandByRayCross(lat, lon, closedCoastRings, bbox, hasCoastData);
     console.debug(`[shore] Origin (${lat.toFixed(5)}, ${lon.toFixed(5)}): inWaterPoly=${originInWater}, isLand=${originIsLand}, hasCoastData=${hasCoastData}`);
 
     const mask = new Float32Array(SHORE_BEARINGS);
@@ -327,7 +513,7 @@ async function analyseShore(lat, lon, onDone) {
            2. Inside an explicit water-area polygon (lake, reservoir…) → sea
               (overrides coastline "land" only for tagged inland water bodies)
            3. No coastline data → open sea (fallback)                        */
-        const isLandCoast = isLandByRayCross(pLat, pLon, coastWays, bbox, hasCoastData);
+        const isLandCoast = isLandByRayCross(pLat, pLon, closedCoastRings, bbox, hasCoastData);
         const inWaterArea = isLandCoast && waterPolys.some(p => pointInPoly(pLat, pLon, p));
 
         let isSea, reason;
@@ -366,6 +552,7 @@ async function analyseShore(lat, lon, onDone) {
       originInWater,
       originIsLand,
       coastWays,                         // raw ways for debug-map drawing
+      closedCoastRings,                  // stitched + closed rings used for classification
       waterPolys,                        // water-area polys for debug-map drawing
       bearings: debugBearings,
     };

--- a/shore.js
+++ b/shore.js
@@ -427,7 +427,39 @@ function findBboxExitCrossing(chain, bbox) {
 function buildClosedCoastRings(coastWays, bbox) {
   const TOL    = 1e-5;
   const chains = stitchCoastWays(coastWays);
-  console.debug(`[shore] stitchCoastWays: ${coastWays.length} ways → ${chains.length} chains`);
+
+  // Second-pass fuzzy stitch: some OSM harbours / bridge gaps leave a chain's
+  // tail ~10–100 m from the next chain's head.  The exact-match pass misses
+  // these; here we connect interior-endpoint pairs within FUZZY_TOL degrees
+  // (~100 m) so that each coast crossing the bbox becomes one continuous chain.
+  const FUZZY_TOL = 0.001;
+  let merged = true;
+  while (merged) {
+    merged = false;
+    outer: for (let i = 0; i < chains.length; i++) {
+      const tail = chains[i][chains[i].length - 1];
+      if (!isInBbox(tail, bbox)) continue;            // only fuzzy-stitch interior tails
+      for (let j = 0; j < chains.length; j++) {
+        if (j === i) continue;
+        const head = chains[j][0];
+        if (!isInBbox(head, bbox)) continue;          // only fuzzy-stitch interior heads
+        if (Math.abs(tail.lat - head.lat) < FUZZY_TOL &&
+            Math.abs(tail.lon - head.lon) < FUZZY_TOL) {
+          console.debug(
+            `[shore] fuzzy-stitch chain[${i}].tail=(${tail.lat.toFixed(4)},${tail.lon.toFixed(4)}) ` +
+            `→ chain[${j}].head=(${head.lat.toFixed(4)},${head.lon.toFixed(4)}) ` +
+            `gap=${(Math.hypot(tail.lat-head.lat, tail.lon-head.lon)*111000).toFixed(0)}m`,
+          );
+          chains[i] = chains[i].concat(chains[j].slice(1));
+          chains.splice(j, 1);
+          merged = true;
+          break outer;
+        }
+      }
+    }
+  }
+
+  console.debug(`[shore] stitchCoastWays: ${coastWays.length} ways → ${chains.length} chains (after fuzzy-stitch)`);
   return chains.map((chain, ci) => {
     const head = chain[0];
     const tail = chain[chain.length - 1];

--- a/shore.js
+++ b/shore.js
@@ -327,13 +327,94 @@ function stitchCoastWays(coastWays) {
   return chains;
 }
 
+/** True if the point lies within (or on the boundary of) the bounding box. */
+function isInBbox(pt, bbox) {
+  return pt.lat >= bbox.s && pt.lat <= bbox.n &&
+         pt.lon >= bbox.w && pt.lon <= bbox.e;
+}
+
+/**
+ * Find where segment p1→p2 first crosses the bbox boundary (t ∈ (0, 1]).
+ * Tests all four edges and returns the crossing with the smallest t > 0
+ * whose intersection point lies on the bbox edge.  Returns null if none.
+ */
+function bboxSegmentCrossing(p1, p2, bbox) {
+  const dLat = p2.lat - p1.lat;
+  const dLon = p2.lon - p1.lon;
+  const EPS  = 1e-9;
+  const candidates = [];
+
+  const tryEdge = (t, lat, lon) => {
+    if (t > EPS && t <= 1 + EPS &&
+        lat >= bbox.s - EPS && lat <= bbox.n + EPS &&
+        lon >= bbox.w - EPS && lon <= bbox.e + EPS) {
+      candidates.push({ t,
+        lat: Math.max(bbox.s, Math.min(bbox.n, lat)),
+        lon: Math.max(bbox.w, Math.min(bbox.e, lon)) });
+    }
+  };
+
+  if (Math.abs(dLon) > EPS) {
+    const tE = (bbox.e - p1.lon) / dLon;
+    tryEdge(tE, p1.lat + tE * dLat, bbox.e);
+    const tW = (bbox.w - p1.lon) / dLon;
+    tryEdge(tW, p1.lat + tW * dLat, bbox.w);
+  }
+  if (Math.abs(dLat) > EPS) {
+    const tN = (bbox.n - p1.lat) / dLat;
+    tryEdge(tN, bbox.n, p1.lon + tN * dLon);
+    const tS = (bbox.s - p1.lat) / dLat;
+    tryEdge(tS, bbox.s, p1.lon + tS * dLon);
+  }
+
+  if (!candidates.length) return null;
+  candidates.sort((a, b) => a.t - b.t);
+  return candidates[0];
+}
+
+/**
+ * Walk the chain from its *head* (index 0) and return the point where the
+ * chain first enters the bbox boundary.  If the first node is already inside,
+ * the first node itself is returned.
+ */
+function findBboxEntryCrossing(chain, bbox) {
+  if (isInBbox(chain[0], bbox)) return chain[0];
+  for (let i = 0; i < chain.length - 1; i++) {
+    if (!isInBbox(chain[i], bbox) && isInBbox(chain[i + 1], bbox)) {
+      return bboxSegmentCrossing(chain[i], chain[i + 1], bbox) ?? chain[i + 1];
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the chain from its *tail* (last index) and return the point where the
+ * chain last exits the bbox boundary.  If the last node is already inside,
+ * the last node itself is returned.
+ */
+function findBboxExitCrossing(chain, bbox) {
+  const last = chain[chain.length - 1];
+  if (isInBbox(last, bbox)) return last;
+  for (let i = chain.length - 1; i > 0; i--) {
+    if (isInBbox(chain[i - 1], bbox) && !isInBbox(chain[i], bbox)) {
+      return bboxSegmentCrossing(chain[i - 1], chain[i], bbox) ?? chain[i - 1];
+    }
+  }
+  return null;
+}
+
 /**
  * Stitch OSM coastline ways into chains, then close every open chain by
- * appending a clockwise bbox-boundary path from the chain's tail back to
- * its head.  Chains that are already closed (islands) are returned as-is.
+ * appending a clockwise bbox-boundary path from the chain's *actual* exit
+ * crossing back to its *actual* entry crossing.
  *
- * The clockwise closure ensures that the winding-number rule correctly
- * classifies sea points even when only a partial coastal slice was fetched.
+ * Using the exact bbox-boundary crossing points (rather than snapping the
+ * chain's raw endpoints) is critical for long coastal ways whose endpoints
+ * lie far outside the bbox: the endpoint's nearest bbox edge may differ from
+ * the edge the chain actually crosses, sending the closure the wrong way
+ * around the bbox and enclosing sea as land.
+ *
+ * Chains that are already closed (islands) are returned unchanged.
  *
  * @param {Array<Array<{lat,lon}>>} coastWays
  * @param {{ s,n,w,e }}             bbox
@@ -349,7 +430,16 @@ function buildClosedCoastRings(coastWays, bbox) {
       Math.abs(head.lat - tail.lat) < TOL &&
       Math.abs(head.lon - tail.lon) < TOL;
     if (closed) return chain;
-    return chain.concat(clockwiseBboxPath(tail, head, bbox));
+
+    // Find the exact points where the chain enters/exits the bbox
+    const entryCrossing = findBboxEntryCrossing(chain, bbox);
+    const exitCrossing  = findBboxExitCrossing(chain, bbox);
+
+    // Fall back to snapping endpoints if crossing detection fails
+    const from = exitCrossing  ?? snapToBbox(tail, bbox);
+    const to   = entryCrossing ?? snapToBbox(head, bbox);
+
+    return chain.concat(clockwiseBboxPath(from, to, bbox));
   });
 }
 

--- a/shore.js
+++ b/shore.js
@@ -254,14 +254,18 @@ function clockwiseBboxPath(from, to, bbox) {
   let   toPos   = cpos(toSnap);
   if (toPos <= fromPos) toPos += 4.0;   // ensure strictly clockwise advance
 
-  const path = [];
+  // Collect corners that fall in (fromPos, toPos), sorted by clockwise position.
+  // We must sort by the shifted cp value — not by ci — because when fromPos > some
+  // native corner cpos values, those corners get shifted by +4 and must appear
+  // AFTER the unshifted corners in the clockwise traversal.
+  const corners = [];
   for (let ci = 0; ci < 4; ci++) {
     let cp = ci;
     while (cp <= fromPos) cp += 4;       // shift corner into (fromPos, ...]
-    if (cp < toPos) path.push(CORNERS[ci]);
+    if (cp < toPos) corners.push({ cp, pt: CORNERS[ci] });
   }
-  path.push(toSnap);
-  return path;
+  corners.sort((a, b) => a.cp - b.cp);
+  return [...corners.map(c => c.pt), toSnap];
 }
 
 /**

--- a/shore.js
+++ b/shore.js
@@ -423,13 +423,17 @@ function findBboxExitCrossing(chain, bbox) {
 function buildClosedCoastRings(coastWays, bbox) {
   const TOL    = 1e-5;
   const chains = stitchCoastWays(coastWays);
-  return chains.map(chain => {
+  console.debug(`[shore] stitchCoastWays: ${coastWays.length} ways → ${chains.length} chains`);
+  return chains.map((chain, ci) => {
     const head = chain[0];
     const tail = chain[chain.length - 1];
     const closed =
       Math.abs(head.lat - tail.lat) < TOL &&
       Math.abs(head.lon - tail.lon) < TOL;
-    if (closed) return chain;
+    if (closed) {
+      console.debug(`[shore] chain[${ci}]: already closed (${chain.length} nodes)`);
+      return chain;
+    }
 
     // Find the exact points where the chain enters/exits the bbox
     const entryCrossing = findBboxEntryCrossing(chain, bbox);
@@ -439,7 +443,20 @@ function buildClosedCoastRings(coastWays, bbox) {
     const from = exitCrossing  ?? snapToBbox(tail, bbox);
     const to   = entryCrossing ?? snapToBbox(head, bbox);
 
-    return chain.concat(clockwiseBboxPath(from, to, bbox));
+    const closure = clockwiseBboxPath(from, to, bbox);
+    console.debug(
+      `[shore] chain[${ci}]: ${chain.length} nodes, ` +
+      `head=(${head.lat.toFixed(4)},${head.lon.toFixed(4)}) ` +
+      `tail=(${tail.lat.toFixed(4)},${tail.lon.toFixed(4)})`,
+    );
+    console.debug(
+      `[shore] chain[${ci}]: entry=(${to.lat.toFixed(4)},${to.lon.toFixed(4)}) ` +
+      `exit=(${from.lat.toFixed(4)},${from.lon.toFixed(4)}) ` +
+      `closure_pts=${closure.length}: ` +
+      closure.map(p => `(${p.lat.toFixed(4)},${p.lon.toFixed(4)})`).join(' → '),
+    );
+
+    return chain.concat(closure);
   });
 }
 

--- a/tests/shore.test.js
+++ b/tests/shore.test.js
@@ -379,6 +379,24 @@ describe('buildClosedCoastRings', () => {
     expect(isLandByRayCross(8, 12, rings, bbox, true)).toBe(true);
   });
 
+  it('E–W coast running EAST (sea to north, OSM sea-left convention) – sea north, land south', () => {
+    // OSM coastlines have sea to the LEFT of the direction of travel (clockwise
+    // around land masses).  For a coast running EASTWARD, left = north = sea,
+    // so land is to the south.  Endpoints lie far SW and SE (outside bbox).
+    const bbox = { s: 5, n: 9, w: 10, e: 14 };
+    const chain = [
+      { lat: 2, lon:  8 },  // far SW, outside bbox
+      { lat: 7, lon: 10 },  // west bbox boundary crossing
+      { lat: 7, lon: 14 },  // east bbox boundary crossing
+      { lat: 2, lon: 16 },  // far SE, outside bbox
+    ];
+    const rings = buildClosedCoastRings([chain], bbox);
+    // Points south of the chain (lat < 7) should be LAND (right of travel)
+    expect(isLandByRayCross(6, 12, rings, bbox, true)).toBe(true);
+    // Points north of the chain (lat > 7) should be SEA (left of travel)
+    expect(isLandByRayCross(8, 12, rings, bbox, true)).toBe(false);
+  });
+
   it('two stitchable N–S ways give the same result as one combined way', () => {
     const combined = [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }, { lat: 9, lon: 12 }];
     const split    = [

--- a/tests/shore.test.js
+++ b/tests/shore.test.js
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { loadScripts } from './helpers/loader.js';
 
 const ctx = loadScripts('config.js', 'shore.js');
-const { destPoint, expandBbox, pointInPoly, signedCrossing, isLandByRayCross, buildOverpassQuery } = ctx;
+const {
+  destPoint, expandBbox, pointInPoly, signedCrossing, isLandByRayCross, buildOverpassQuery,
+  snapToBbox, clockwiseBboxPath, stitchCoastWays, buildClosedCoastRings,
+} = ctx;
 
 // ── destPoint ─────────────────────────────────────────────────────────────
 
@@ -140,6 +143,153 @@ describe('isLandByRayCross', () => {
     ];
     const isLand = isLandByRayCross(5, 5, [landRing], null, true);
     expect(isLand).toBe(false);
+  });
+});
+
+// ── snapToBbox ────────────────────────────────────────────────────────────
+
+describe('snapToBbox', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('snaps a point north of the bbox to the north edge', () => {
+    const snapped = snapToBbox({ lat: 11, lon: 12 }, bbox);
+    expect(snapped.lat).toBe(9);
+    expect(snapped.lon).toBe(12);
+  });
+
+  it('snaps a point east of the bbox to the east edge', () => {
+    const snapped = snapToBbox({ lat: 7, lon: 20 }, bbox);
+    expect(snapped.lon).toBe(14);
+    expect(snapped.lat).toBe(7);
+  });
+
+  it('snaps a point south of the bbox to the south edge', () => {
+    const snapped = snapToBbox({ lat: 2, lon: 12 }, bbox);
+    expect(snapped.lat).toBe(5);
+    expect(snapped.lon).toBe(12);
+  });
+
+  it('snaps a point west of the bbox to the west edge', () => {
+    const snapped = snapToBbox({ lat: 7, lon: 5 }, bbox);
+    expect(snapped.lon).toBe(10);
+    expect(snapped.lat).toBe(7);
+  });
+});
+
+// ── clockwiseBboxPath ─────────────────────────────────────────────────────
+
+describe('clockwiseBboxPath', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('from north edge to south edge includes NE and SE corners', () => {
+    // Exit on north at lon=12, entry on south at lon=12 – going CW means passing NE then SE
+    const path = clockwiseBboxPath({ lat: 9, lon: 12 }, { lat: 5, lon: 12 }, bbox);
+    const lons = path.map(p => p.lon);
+    expect(lons).toContain(14);  // east edge (NE and SE corners)
+    expect(lons).not.toContain(10); // west edge corners should not be in path
+    // Destination point (south edge) is the last element
+    expect(path[path.length - 1]).toEqual({ lat: 5, lon: 12 });
+  });
+
+  it('from east edge to west edge includes SE and SW corners', () => {
+    // Exit on east at lat=7, entry on west at lat=7 – CW: SE then SW
+    const path = clockwiseBboxPath({ lat: 7, lon: 14 }, { lat: 7, lon: 10 }, bbox);
+    const lats = path.map(p => p.lat);
+    expect(lats).toContain(5);   // south edge (SE and SW corners)
+    expect(lats).not.toContain(9); // north corners should not appear
+    expect(path[path.length - 1]).toEqual({ lat: 7, lon: 10 });
+  });
+
+  it('path endpoint is the snapped `to` point', () => {
+    const path = clockwiseBboxPath({ lat: 9, lon: 11 }, { lat: 5, lon: 13 }, bbox);
+    expect(path[path.length - 1]).toEqual({ lat: 5, lon: 13 });
+  });
+});
+
+// ── stitchCoastWays ───────────────────────────────────────────────────────
+
+describe('stitchCoastWays', () => {
+  it('stitches two connected ways into a single chain', () => {
+    const wayA = [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }];
+    const wayB = [{ lat: 7, lon: 12 }, { lat: 9, lon: 12 }];
+    const chains = stitchCoastWays([wayA, wayB]);
+    expect(chains.length).toBe(1);
+    expect(chains[0].length).toBe(3);
+    expect(chains[0][0]).toEqual({ lat: 5, lon: 12 });
+    expect(chains[0][2]).toEqual({ lat: 9, lon: 12 });
+  });
+
+  it('stitches a reversed second way correctly', () => {
+    const wayA = [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }];
+    const wayB = [{ lat: 9, lon: 12 }, { lat: 7, lon: 12 }]; // reversed relative to chain direction
+    const chains = stitchCoastWays([wayA, wayB]);
+    expect(chains.length).toBe(1);
+    expect(chains[0][0]).toEqual({ lat: 5, lon: 12 });
+    expect(chains[0][chains[0].length - 1]).toEqual({ lat: 9, lon: 12 });
+  });
+
+  it('recognises a closed ring after stitching', () => {
+    // Two half-rings that together form a complete closed island ring
+    const wayA = [{ lat: 1, lon: -1 }, { lat: 1, lon: 1 }];
+    const wayB = [{ lat: 1, lon: 1 }, { lat: -1, lon: 1 }, { lat: -1, lon: -1 }, { lat: 1, lon: -1 }];
+    const chains = stitchCoastWays([wayA, wayB]);
+    expect(chains.length).toBe(1);
+    const c = chains[0];
+    // Head and tail should be the same point (closed)
+    expect(c[0].lat).toBeCloseTo(c[c.length - 1].lat, 5);
+    expect(c[0].lon).toBeCloseTo(c[c.length - 1].lon, 5);
+  });
+
+  it('keeps unconnected ways as separate chains', () => {
+    const wayA = [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }];
+    const wayB = [{ lat: 1, lon: 0  }, { lat: 2, lon: 0  }];
+    const chains = stitchCoastWays([wayA, wayB]);
+    expect(chains.length).toBe(2);
+  });
+});
+
+// ── buildClosedCoastRings ─────────────────────────────────────────────────
+
+describe('buildClosedCoastRings', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('regression: open N–S coast at lon=12 (sea to the west) – sea west and land east', () => {
+    // Before the fix, the winding number from this open chain gave +1 for the sea
+    // point at (7, 11), misclassifying it as land.
+    const openCoastWay = [
+      { lat: 5, lon: 12 },  // south entry on bbox boundary
+      { lat: 9, lon: 12 },  // north exit on bbox boundary
+    ];
+    const rings = buildClosedCoastRings([openCoastWay], bbox);
+    expect(isLandByRayCross(7, 11, rings, bbox, true)).toBe(false);  // west = SEA
+    expect(isLandByRayCross(7, 13, rings, bbox, true)).toBe(true);   // east = LAND
+  });
+
+  it('closed island ring (two stitched ways) stays closed and classifies correctly', () => {
+    const wayA = [{ lat:  1, lon: -1 }, { lat: 1, lon: 1 }];
+    const wayB = [{ lat:  1, lon:  1 }, { lat: -1, lon: 1 }, { lat: -1, lon: -1 }, { lat: 1, lon: -1 }];
+    const islandBbox = { s: -2, n: 2, w: -2, e: 2 };
+    const rings = buildClosedCoastRings([wayA, wayB], islandBbox);
+    expect(rings.length).toBe(1);
+    // Interior of island = land
+    expect(isLandByRayCross(0, 0, rings, islandBbox, true)).toBe(true);
+    // Exterior of island = sea
+    expect(isLandByRayCross(5, 5, rings, islandBbox, true)).toBe(false);
+  });
+
+  it('two stitchable N–S ways give the same result as one combined way', () => {
+    const combined = [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }, { lat: 9, lon: 12 }];
+    const split    = [
+      [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }],
+      [{ lat: 7, lon: 12 }, { lat: 9, lon: 12 }],
+    ];
+    const ringsCombined = buildClosedCoastRings([combined], bbox);
+    const ringsSplit    = buildClosedCoastRings(split,      bbox);
+    // Both should classify the same test points identically
+    for (const [lat, lon] of [[7, 11], [7, 13], [6, 11.5], [8, 12.5]]) {
+      expect(isLandByRayCross(lat, lon, ringsCombined, bbox, true))
+        .toBe(isLandByRayCross(lat, lon, ringsSplit, bbox, true));
+    }
   });
 });
 

--- a/tests/shore.test.js
+++ b/tests/shore.test.js
@@ -5,6 +5,7 @@ const ctx = loadScripts('config.js', 'shore.js');
 const {
   destPoint, expandBbox, pointInPoly, signedCrossing, isLandByRayCross, buildOverpassQuery,
   snapToBbox, clockwiseBboxPath, stitchCoastWays, buildClosedCoastRings,
+  isInBbox, bboxSegmentCrossing, findBboxEntryCrossing, findBboxExitCrossing,
 } = ctx;
 
 // ── destPoint ─────────────────────────────────────────────────────────────
@@ -248,6 +249,82 @@ describe('stitchCoastWays', () => {
   });
 });
 
+// ── isInBbox / bboxSegmentCrossing / findBboxEntryCrossing / findBboxExitCrossing ──
+
+describe('isInBbox', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('returns true for a point inside', () => {
+    expect(isInBbox({ lat: 7, lon: 12 }, bbox)).toBe(true);
+  });
+
+  it('returns false for a point outside', () => {
+    expect(isInBbox({ lat: 10, lon: 12 }, bbox)).toBe(false);
+    expect(isInBbox({ lat: 7, lon: 15 }, bbox)).toBe(false);
+  });
+
+  it('returns true for a point on the boundary', () => {
+    expect(isInBbox({ lat: 9, lon: 12 }, bbox)).toBe(true);
+  });
+});
+
+describe('bboxSegmentCrossing', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('finds east-edge crossing for a segment going right', () => {
+    const c = bboxSegmentCrossing({ lat: 7, lon: 12 }, { lat: 7, lon: 16 }, bbox);
+    expect(c.lat).toBeCloseTo(7, 5);
+    expect(c.lon).toBeCloseTo(14, 5);
+  });
+
+  it('finds north-edge crossing for a segment going up', () => {
+    const c = bboxSegmentCrossing({ lat: 7, lon: 12 }, { lat: 11, lon: 12 }, bbox);
+    expect(c.lat).toBeCloseTo(9, 5);
+    expect(c.lon).toBeCloseTo(12, 5);
+  });
+
+  it('returns null for a segment that does not cross the bbox', () => {
+    // Both outside, does not cross
+    expect(bboxSegmentCrossing({ lat: 0, lon: 0 }, { lat: 1, lon: 1 }, bbox)).toBeNull();
+  });
+});
+
+describe('findBboxEntryCrossing', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('returns first node when chain starts inside bbox', () => {
+    const chain = [{ lat: 7, lon: 12 }, { lat: 8, lon: 12 }];
+    const c = findBboxEntryCrossing(chain, bbox);
+    expect(c.lat).toBe(7);
+    expect(c.lon).toBe(12);
+  });
+
+  it('finds the crossing when chain starts outside and enters from south', () => {
+    const chain = [{ lat: 3, lon: 12 }, { lat: 7, lon: 12 }];
+    const c = findBboxEntryCrossing(chain, bbox);
+    expect(c.lat).toBeCloseTo(5, 4);
+    expect(c.lon).toBeCloseTo(12, 4);
+  });
+});
+
+describe('findBboxExitCrossing', () => {
+  const bbox = { s: 5, n: 9, w: 10, e: 14 };
+
+  it('returns last node when chain ends inside bbox', () => {
+    const chain = [{ lat: 7, lon: 12 }, { lat: 8, lon: 13 }];
+    const c = findBboxExitCrossing(chain, bbox);
+    expect(c.lat).toBe(8);
+    expect(c.lon).toBe(13);
+  });
+
+  it('finds the crossing when chain exits through the north edge', () => {
+    const chain = [{ lat: 7, lon: 12 }, { lat: 11, lon: 12 }];
+    const c = findBboxExitCrossing(chain, bbox);
+    expect(c.lat).toBeCloseTo(9, 4);
+    expect(c.lon).toBeCloseTo(12, 4);
+  });
+});
+
 // ── buildClosedCoastRings ─────────────────────────────────────────────────
 
 describe('buildClosedCoastRings', () => {
@@ -275,6 +352,31 @@ describe('buildClosedCoastRings', () => {
     expect(isLandByRayCross(0, 0, rings, islandBbox, true)).toBe(true);
     // Exterior of island = sea
     expect(isLandByRayCross(5, 5, rings, islandBbox, true)).toBe(false);
+  });
+
+  it('regression (Vordingborg): E–W coast whose raw endpoints lie far NE/NW of bbox', () => {
+    // The chain represents a coast running west across the bbox (sea to south).
+    // Its OSM-way endpoints are far outside the bbox — one to the NE, one to the NW.
+    // Before the bbox-crossing fix, both endpoints snapped to the north edge;
+    // the CW closure then went the long way round (via SE/SW corners) and
+    // enclosed the southern sea area as land.
+    // After the fix, actual crossing points on the east/west edges are used,
+    // and the closure correctly goes via the NW/NE corners (land to the north).
+    const bbox = { s: 5, n: 9, w: 10, e: 14 };
+    // Chain: starts far NE (lat=12, lon=16), crosses east bbox edge, runs west
+    // through the bbox at lat=7, crosses west bbox edge, ends far NW (lat=12, lon=8).
+    const chain = [
+      { lat: 12, lon: 16 },  // far NE, outside bbox
+      { lat:  7, lon: 14 },  // east bbox boundary crossing area
+      { lat:  7, lon: 10 },  // west bbox boundary crossing area
+      { lat: 12, lon:  8 },  // far NW, outside bbox
+    ];
+    const rings = buildClosedCoastRings([chain], bbox);
+    // Points south of the chain (lat < 7) should be SEA
+    expect(isLandByRayCross(6, 12, rings, bbox, true)).toBe(false);
+    expect(isLandByRayCross(5.5, 11, rings, bbox, true)).toBe(false);
+    // Points north of the chain (lat > 7) should be LAND
+    expect(isLandByRayCross(8, 12, rings, bbox, true)).toBe(true);
   });
 
   it('two stitchable N–S ways give the same result as one combined way', () => {

--- a/tests/shore.test.js
+++ b/tests/shore.test.js
@@ -397,6 +397,30 @@ describe('buildClosedCoastRings', () => {
     expect(isLandByRayCross(8, 12, rings, bbox, true)).toBe(false);
   });
 
+  it('U-shaped coast (entry and exit on same south edge) – only encloses peninsula, not the whole bbox', () => {
+    // A peninsula sticking north from below the bbox enters and exits through
+    // the south edge.  The bbox closure must NOT wrap all the way around
+    // (which would classify the entire bbox interior as land).  Instead it
+    // should close directly along the south edge so that only the peninsula
+    // interior is land, and the open sea to the north remains sea.
+    const bbox = { s: 5, n: 9, w: 10, e: 14 };
+    // Chain: comes from far south, enters south edge at lon=11.5, goes north
+    // to lon=12, turns back south, exits south edge at lon=12.5, exits south.
+    // Sea-left convention: going north on left leg → sea to west; going south
+    // on right leg → sea to east.  Interior of U = land (peninsula).
+    const chain = [
+      { lat: 3, lon: 11.5 },  // far south, outside bbox
+      { lat: 7, lon: 11.5 },  // inside, west leg going north
+      { lat: 7, lon: 12.5 },  // inside, top of peninsula
+      { lat: 3, lon: 12.5 },  // far south, outside bbox
+    ];
+    const rings = buildClosedCoastRings([chain], bbox);
+    // Inside the U (peninsula interior) → LAND
+    expect(isLandByRayCross(6, 12, rings, bbox, true)).toBe(true);
+    // Well north of the peninsula (open sea area above) → SEA
+    expect(isLandByRayCross(8, 12, rings, bbox, true)).toBe(false);
+  });
+
   it('two stitchable N–S ways give the same result as one combined way', () => {
     const combined = [{ lat: 5, lon: 12 }, { lat: 7, lon: 12 }, { lat: 9, lon: 12 }];
     const split    = [


### PR DESCRIPTION
## Problem

Overpass returns only the coastline ways that intersect the query bbox — partial open chains. The winding-number algorithm (`isLandByRayCross`) requires closed rings, so open chains caused incorrect land/sea classification (e.g., a coastal point near Vordingborg was incorrectly marked as inland).

## Solution

Five fixes across `shore.js` and `tests/shore.test.js`:

**Core fix** (`1ccee36`) — Stitch and close open chains:
- `stitchCoastWays` — joins way segments into continuous chains by matching shared endpoints
- `buildClosedCoastRings` — closes each chain by traversing the bbox boundary clockwise from exit back to entry
- `analyseShore` now uses these closed rings before classifying points

**Crossing-point fix** (`cf67232`) — Use actual bbox crossing points:
- Raw OSM endpoints of long ways snapped to the wrong bbox edge, causing the closure ring to enclose the sea as land
- Fix: `findBboxEntryCrossing`/`findBboxExitCrossing` walk the chain to find the exact lat/lon where it crosses the bbox boundary

**Corner ordering fix** (`ee8b518`) — Fix `clockwiseBboxPath`:
- Corners were emitted in array-index order instead of sorted clockwise position
- Fix: collect `{cp, pt}` pairs and sort by clockwise position before appending

**Fuzzy-stitch pass** (`2ae49c8`) — Bridge harbour/bridge gaps:
- Some OSM chains have ~10–100 m gaps (harbours, bridges) that break the exact-match stitch
- Fix: second pass connecting interior chain endpoints within 0.001° (~100 m)

**Same-edge U-shape fix** (`3b3635a`) — Avoid wrapping the entire bbox:
- When a chain's entry and exit are both on the same bbox edge, going the full perimeter clockwise wrongly enclosed the whole bbox as land
- Fix: detect when `floor(fromPos) === floor(origToPos)` and close directly along that edge

## Tests

93 tests pass, including:
- Regression tests for N–S and E–W coasts using the correct OSM sea-left convention
- U-shaped coast regression (same-edge entry/exit)
- Two-way stitch tests