### PR TITLE
Enable full-forecast horizontal scrolling in portrait mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
    MAIN APP — load, tooltip, kite dialog, URL sync
 ══════════════════════════════════════════════════ */
 var lastData        = null;
+var lastRenderedData = null; // the sliced data passed to the most recent renderAll call
 let lastShoreCoords = null;  // { lat, lon } of the last loaded city
 
 function syncInvertedColorsClass() {
@@ -161,8 +162,12 @@ async function load(cityName, model) {
 }
 /* ══════════════════════════════════════════════════
    PORTRAIT-AWARE RENDERING
-   In portrait mode only the first 36 h are shown.
+   In portrait mode the full remaining forecast is shown in a scrollable
+   canvas — each 3-hour slot is PORTRAIT_COL_W px wide so one icon fits
+   per slot, and the user can swipe to travel through time.
 ══════════════════════════════════════════════════ */
+const PORTRAIT_COL_W = 36; // px per 3-hour slot in portrait scroll mode
+
 function slicePercentilesFrom(obj, start, n) {
   if (!obj) return null;
   return { p10: obj.p10.slice(start, start + n), p50: obj.p50.slice(start, start + n), p90: obj.p90.slice(start, start + n) };
@@ -172,10 +177,8 @@ function renderDisplay(d) {
   const portrait       = window.matchMedia('(orientation: portrait)').matches;
   const invertedColors = window.matchMedia('(inverted-colors: inverted)').matches;
   syncInvertedColorsClass();
-  const hours = portrait ? 36 : FORECAST_DAYS * 24;
-  const n3h = Math.ceil(hours / STEP);
-  const n1h = Math.ceil(hours / STEP1H);
-  // In portrait, start from the current time rather than midnight.
+  // In portrait, start from the current time and show the full remaining forecast
+  // (scrollable). In landscape show the full 7-day window from midnight.
   let s3 = 0, s1 = 0;
   if (portrait) {
     const now = Date.now();
@@ -187,6 +190,8 @@ function renderDisplay(d) {
     const i1 = d.times1h.findIndex(t => new Date(t).getTime() >= startTime);
     s1 = i1 >= 0 ? i1 : 0;
   }
+  const n3h = portrait ? d.times.length - s3 : Math.ceil(FORECAST_DAYS * 24 / STEP);
+  const n1h = portrait ? d.times1h.length - s1 : Math.ceil(FORECAST_DAYS * 24 / STEP1H);
   const s = {
     times:    d.times.slice(s3, s3 + n3h),    temps:    d.temps.slice(s3, s3 + n3h),
     precips:  d.precips.slice(s3, s3 + n3h),  gusts:    d.gusts.slice(s3, s3 + n3h),
@@ -200,7 +205,9 @@ function renderDisplay(d) {
     ensTemp1h:  slicePercentilesFrom(d.ensTemp1h,  s1, n1h), ensWind1h:  slicePercentilesFrom(d.ensWind1h,  s1, n1h),
     ensGust1h:  slicePercentilesFrom(d.ensGust1h,  s1, n1h), ensPrecip1h: slicePercentilesFrom(d.ensPrecip1h, s1, n1h),
   };
-  renderAll(s, invertedColors);
+  const colW = portrait ? PORTRAIT_COL_W : null;
+  renderAll(s, invertedColors, colW);
+  lastRenderedData = s;
   if (invertedColors) {
     ['c-top', 'c-temp', 'c-dir', 'c-wind'].forEach(id => {
       const canvas = document.getElementById(id);
@@ -231,8 +238,8 @@ function clearCrosshairs() {
   });
 }
 function drawCrosshairs(fracX, idx1h, idx3h) {
-  if (!lastData) return;
-  const d = lastData;
+  if (!lastRenderedData) return;
+  const d = lastRenderedData;
   // Re-derive the same y-mappings used by the draw functions
   const TEMP_cssH = 130, TEMP_padT = 8, TEMP_padB = 8;
   const TEMP_ch   = TEMP_cssH - TEMP_padT - TEMP_padB;
@@ -299,8 +306,8 @@ const WMO_DESC = {
   95:'Thunderstorm',96:'Thunderstorm w/ hail',99:'Thunderstorm w/ heavy hail',
 };
 function showTooltip(idx1h, idx3h) {
-  if (!lastData) return;
-  const d = lastData;
+  if (!lastRenderedData) return;
+  const d = lastRenderedData;
   const tip = document.getElementById('hover-tooltip');
   // Time label from 1hr array for precision
   const t    = new Date(d.times1h[idx1h]);
@@ -391,15 +398,15 @@ function hideTooltip() {
 function attachHoverListeners() {
   const content = document.getElementById('forecast-content');
   content.addEventListener('mousemove', e => {
-    if (!lastData) return;
+    if (!lastRenderedData) return;
     const wrap = e.target.closest('.chart-canvas-wrap');
     if (!wrap) { hideTooltip(); return; }
     const rect  = wrap.getBoundingClientRect();
     const relX  = e.clientX - rect.left;
     const span  = rect.width;
     const fracX    = Math.max(0, Math.min(1, relX / span));
-    const n1h      = lastData.times1h.length;
-    const n3h      = lastData.times.length;
+    const n1h      = lastRenderedData.times1h.length;
+    const n3h      = lastRenderedData.times.length;
     const idx1h    = Math.min(n1h - 1, Math.floor(fracX * n1h));
     const idx3h    = Math.min(n3h - 1, Math.floor(fracX * n3h));
     drawCrosshairs(fracX, idx1h, idx3h);

--- a/app.js
+++ b/app.js
@@ -166,7 +166,7 @@ async function load(cityName, model) {
    canvas — each 3-hour slot is PORTRAIT_COL_W px wide so one icon fits
    per slot, and the user can swipe to travel through time.
 ══════════════════════════════════════════════════ */
-const PORTRAIT_COL_W = 36; // px per 3-hour slot in portrait scroll mode
+const PORTRAIT_COL_W = 24; // px per 3-hour slot in portrait scroll mode
 
 function slicePercentilesFrom(obj, start, n) {
   if (!obj) return null;

--- a/app.js
+++ b/app.js
@@ -402,8 +402,10 @@ function attachHoverListeners() {
     const wrap = e.target.closest('.chart-canvas-wrap');
     if (!wrap) { hideTooltip(); return; }
     const rect  = wrap.getBoundingClientRect();
-    const relX  = e.clientX - rect.left;
-    const span  = rect.width;
+    // In portrait the wrap scrolls horizontally; add scrollLeft so relX is
+    // measured in canvas coordinates, not visible-viewport coordinates.
+    const relX  = e.clientX - rect.left + (wrap.scrollLeft || 0);
+    const span  = wrap.scrollWidth || rect.width;
     const fracX    = Math.max(0, Math.min(1, relX / span));
     const n1h      = lastRenderedData.times1h.length;
     const n3h      = lastRenderedData.times.length;
@@ -415,6 +417,27 @@ function attachHoverListeners() {
   content.addEventListener('mouseleave', hideTooltip);
 }
 attachHoverListeners();
+
+/* ══════════════════════════════════════════════════
+   PORTRAIT SCROLL SYNC
+   Keep all four .chart-canvas-wrap scroll containers in step so that
+   scrolling any one of them moves the others to the same position.
+══════════════════════════════════════════════════ */
+function initPortraitScrollSync() {
+  const wraps = document.querySelectorAll ? [...document.querySelectorAll('.chart-canvas-wrap')] : [];
+  let syncing = false;
+  wraps.forEach(wrap => {
+    wrap.addEventListener('scroll', () => {
+      if (syncing) return;
+      syncing = true;
+      const left = wrap.scrollLeft;
+      wraps.forEach(w => { if (w !== wrap) w.scrollLeft = left; });
+      syncing = false;
+    }, { passive: true });
+  });
+}
+initPortraitScrollSync();
+
 function getModel() { return document.getElementById('model-select').value; }
 /* ══════════════════════════════════════════════════
    SHORE STATUS UI

--- a/charts.js
+++ b/charts.js
@@ -772,11 +772,15 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
    RENDER ALL
 ══════════════════════════════════════════════════ */
 function renderAll(d, invertedColors, portraitColW = null) {
+  // The icon/direction rows use 3-hour data; temp/wind rows use 1-hour data
+  // (3× more columns). Pass colW / 3 to the 1h functions so all four canvases
+  // have the same total CSS width and scroll stays in sync with the time axis.
+  const portrait1hColW = portraitColW != null ? portraitColW / 3 : null;
   drawTopRow(d.times, d.codes, d.precips, invertedColors, portraitColW);
   drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
-           d.times, d.precips, d.ensPrecip || null, portraitColW);
+           d.times, d.precips, d.ensPrecip || null, portrait1hColW);
   drawWindDir(d.times, d.winds, d.dirs, portraitColW);
   drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
-           d.times, d.winds, invertedColors, portraitColW);
+           d.times, d.winds, invertedColors, portrait1hColW);
 }
 

--- a/charts.js
+++ b/charts.js
@@ -38,12 +38,12 @@ function resolveDPI(canvas, cssW, cssH) {
 /* ══════════════════════════════════════════════════
    DRAW TOP ROW (time axis + icons + UV + wind dirs)
 ══════════════════════════════════════════════════ */
-function drawTopRow(times, codes, precips, invertedColors, portraitColW = null) {
+function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
   const canvas = document.getElementById('c-top');
   const wrap   = canvas.parentElement;
   const n      = times.length;
-  const colW   = portraitColW != null ? portraitColW : wrap.clientWidth / n;
-  const cssW   = portraitColW != null ? n * colW : wrap.clientWidth;
+  const cssW   = totalCssW != null ? totalCssW : wrap.clientWidth;
+  const colW   = cssW / n;
 
   const ICON_H   = 36;
   const TIME_H   = 18;
@@ -160,12 +160,12 @@ function drawTopRow(times, codes, precips, invertedColors, portraitColW = null) 
 /* ══════════════════════════════════════════════════
    DRAW TEMP + PRECIP
 ══════════════════════════════════════════════════ */
-function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h, ensPrecip3h, portraitColW = null) {
+function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h, ensPrecip3h, totalCssW = null) {
   const canvas = document.getElementById('c-temp');
   const wrap   = canvas.parentElement;
   const n      = times.length;
-  const colW   = portraitColW != null ? portraitColW : wrap.clientWidth / n;
-  const cssW   = portraitColW != null ? n * colW : wrap.clientWidth;
+  const cssW   = totalCssW != null ? totalCssW : wrap.clientWidth;
+  const colW   = cssW / n;
   const cssH   = 130;
   const ctx    = resolveDPI(canvas, cssW, cssH);
   ctx.clearRect(0,0,cssW,cssH);
@@ -405,12 +405,12 @@ function isKiteOptimal(speed, deg, timeStr) {
 /* ══════════════════════════════════════════════════
    DRAW WIND DIRECTION ROW
 ══════════════════════════════════════════════════ */
-function drawWindDir(times, winds, dirs, portraitColW = null) {
+function drawWindDir(times, winds, dirs, totalCssW = null) {
   const canvas = document.getElementById('c-dir');
   const wrap   = canvas.parentElement;
   const n      = times.length;
-  const colW   = portraitColW != null ? portraitColW : wrap.clientWidth / n;
-  const cssW   = portraitColW != null ? n * colW : wrap.clientWidth;
+  const cssW   = totalCssW != null ? totalCssW : wrap.clientWidth;
+  const colW   = cssW / n;
   // Compress row height when columns are narrow so arrows always fit snugly.
   // Arrow geometry: tip is size*0.76 above cy, shaft bottom is size*0.50 below cy → total span = size*1.26
   const arrowSize = Math.min(colW * 0.72, 22);
@@ -656,12 +656,12 @@ function _drawWindAxisLabels(wLevels, wy, WIND_H) {
 ══════════════════════════════════════════════════ */
 // times/gusts/winds are 1hr resolution; dirs is 3hr (same as drawWindDir);
 // times3h/winds3h are the 3hr arrays used only for kite highlights & pills.
-function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, portraitColW = null) {
+function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null) {
   // --- canvas setup ---
   const canvas = document.getElementById('c-wind');
   const n      = times.length;
-  const colW   = portraitColW != null ? portraitColW : canvas.parentElement.clientWidth / n;
-  const cssW   = portraitColW != null ? n * colW : canvas.parentElement.clientWidth;
+  const cssW   = totalCssW != null ? totalCssW : canvas.parentElement.clientWidth;
+  const colW   = cssW / n;
   const WIND_H = 130;
   const ctx    = resolveDPI(canvas, cssW, WIND_H);
   ctx.clearRect(0, 0, cssW, WIND_H);
@@ -772,15 +772,17 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
    RENDER ALL
 ══════════════════════════════════════════════════ */
 function renderAll(d, invertedColors, portraitColW = null) {
-  // The icon/direction rows use 3-hour data; temp/wind rows use 1-hour data
-  // (3× more columns). Pass colW / 3 to the 1h functions so all four canvases
-  // have the same total CSS width and scroll stays in sync with the time axis.
-  const portrait1hColW = portraitColW != null ? portraitColW / 3 : null;
-  drawTopRow(d.times, d.codes, d.precips, invertedColors, portraitColW);
+  // Compute a single total canvas width anchored to the 3-hour slot count.
+  // Every draw function receives this same value so all four canvases are
+  // *exactly* the same CSS width, guaranteeing perfect time-axis alignment
+  // when the user scrolls — regardless of whether a function uses 3 h or 1 h
+  // resolution data.
+  const totalCssW = portraitColW != null ? d.times.length * portraitColW : null;
+  drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
   drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
-           d.times, d.precips, d.ensPrecip || null, portrait1hColW);
-  drawWindDir(d.times, d.winds, d.dirs, portraitColW);
+           d.times, d.precips, d.ensPrecip || null, totalCssW);
+  drawWindDir(d.times, d.winds, d.dirs, totalCssW);
   drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
-           d.times, d.winds, invertedColors, portrait1hColW);
+           d.times, d.winds, invertedColors, totalCssW);
 }
 

--- a/charts.js
+++ b/charts.js
@@ -38,11 +38,12 @@ function resolveDPI(canvas, cssW, cssH) {
 /* ══════════════════════════════════════════════════
    DRAW TOP ROW (time axis + icons + UV + wind dirs)
 ══════════════════════════════════════════════════ */
-function drawTopRow(times, codes, precips, invertedColors) {
+function drawTopRow(times, codes, precips, invertedColors, portraitColW = null) {
   const canvas = document.getElementById('c-top');
   const wrap   = canvas.parentElement;
-  const cssW   = wrap.clientWidth;
   const n      = times.length;
+  const colW   = portraitColW != null ? portraitColW : wrap.clientWidth / n;
+  const cssW   = portraitColW != null ? n * colW : wrap.clientWidth;
 
   const ICON_H   = 36;
   const TIME_H   = 18;
@@ -50,8 +51,6 @@ function drawTopRow(times, codes, precips, invertedColors) {
 
   const ctx = resolveDPI(canvas, cssW, cssH);
   ctx.clearRect(0,0,cssW,cssH);
-
-  const colW = cssW / n;
   const divs = dayDivs(times);
 
   // When inverted colors is active, the canvas is pre-inverted by JS so that
@@ -161,16 +160,15 @@ function drawTopRow(times, codes, precips, invertedColors) {
 /* ══════════════════════════════════════════════════
    DRAW TEMP + PRECIP
 ══════════════════════════════════════════════════ */
-function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h, ensPrecip3h) {
+function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h, ensPrecip3h, portraitColW = null) {
   const canvas = document.getElementById('c-temp');
   const wrap   = canvas.parentElement;
-  const cssW   = wrap.clientWidth;
+  const n      = times.length;
+  const colW   = portraitColW != null ? portraitColW : wrap.clientWidth / n;
+  const cssW   = portraitColW != null ? n * colW : wrap.clientWidth;
   const cssH   = 130;
   const ctx    = resolveDPI(canvas, cssW, cssH);
   ctx.clearRect(0,0,cssW,cssH);
-
-  const n = times.length;
-  const colW = cssW / n;
   const padT=8, padB=8, ch=cssH-padT-padB;
   let tmin=Math.floor(Math.min(...temps)/5)*5;
   let tmax=Math.ceil( Math.max(...temps)/5)*5;
@@ -407,12 +405,12 @@ function isKiteOptimal(speed, deg, timeStr) {
 /* ══════════════════════════════════════════════════
    DRAW WIND DIRECTION ROW
 ══════════════════════════════════════════════════ */
-function drawWindDir(times, winds, dirs) {
+function drawWindDir(times, winds, dirs, portraitColW = null) {
   const canvas = document.getElementById('c-dir');
   const wrap   = canvas.parentElement;
-  const cssW   = wrap.clientWidth;
   const n      = times.length;
-  const colW   = cssW / n;
+  const colW   = portraitColW != null ? portraitColW : wrap.clientWidth / n;
+  const cssW   = portraitColW != null ? n * colW : wrap.clientWidth;
   // Compress row height when columns are narrow so arrows always fit snugly.
   // Arrow geometry: tip is size*0.76 above cy, shaft bottom is size*0.50 below cy → total span = size*1.26
   const arrowSize = Math.min(colW * 0.72, 22);
@@ -658,16 +656,15 @@ function _drawWindAxisLabels(wLevels, wy, WIND_H) {
 ══════════════════════════════════════════════════ */
 // times/gusts/winds are 1hr resolution; dirs is 3hr (same as drawWindDir);
 // times3h/winds3h are the 3hr arrays used only for kite highlights & pills.
-function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors) {
+function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, portraitColW = null) {
   // --- canvas setup ---
   const canvas = document.getElementById('c-wind');
-  const cssW   = canvas.parentElement.clientWidth;
+  const n      = times.length;
+  const colW   = portraitColW != null ? portraitColW : canvas.parentElement.clientWidth / n;
+  const cssW   = portraitColW != null ? n * colW : canvas.parentElement.clientWidth;
   const WIND_H = 130;
   const ctx    = resolveDPI(canvas, cssW, WIND_H);
   ctx.clearRect(0, 0, cssW, WIND_H);
-
-  const n    = times.length;
-  const colW = cssW / n;
   const divs = dayDivs(times);
   const cx2  = i => (i + 0.5) * colW;
 
@@ -774,12 +771,12 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
 /* ══════════════════════════════════════════════════
    RENDER ALL
 ══════════════════════════════════════════════════ */
-function renderAll(d, invertedColors) {
-  drawTopRow(d.times, d.codes, d.precips, invertedColors);
+function renderAll(d, invertedColors, portraitColW = null) {
+  drawTopRow(d.times, d.codes, d.precips, invertedColors, portraitColW);
   drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
-           d.times, d.precips, d.ensPrecip || null);
-  drawWindDir(d.times, d.winds, d.dirs);
+           d.times, d.precips, d.ensPrecip || null, portraitColW);
+  drawWindDir(d.times, d.winds, d.dirs, portraitColW);
   drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
-           d.times, d.winds, invertedColors);
+           d.times, d.winds, invertedColors, portraitColW);
 }
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -80,6 +80,7 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
         if (id === 'model-select') return makeEl('dmi_seamless');
         return makeEl();
       },
+      querySelectorAll: () => [],
       body: { classList: { toggle: () => {}, contains: () => false } },
     },
     localStorage: mockLocalStorage,

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -272,13 +272,17 @@ describe('renderDisplay slicing', () => {
   const TOTAL_3H = (7 * 24) / 3;   // 56 — full 7-day dataset at 3-hour step
   const TOTAL_1H = 7 * 24;         // 168
 
-  it('slices to 36 h in portrait mode (12×3h entries, 36×1h entries)', () => {
+  it('shows all remaining forecast data from current time in portrait (no 36-hour cap)', () => {
     const calls = [];
     const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
-    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    const d = makeData(TOTAL_3H, TOTAL_1H);
+    ctx.renderDisplay(d);
     expect(calls).toHaveLength(1);
-    expect(calls[0].times).toHaveLength(12);     // 36 / 3
-    expect(calls[0].times1h).toHaveLength(36);   // 36 / 1
+    // Should extend to the very end of the input dataset (not capped at 36 h)
+    expect(calls[0].times.at(-1)).toBe(d.times.at(-1));
+    expect(calls[0].times1h.at(-1)).toBe(d.times1h.at(-1));
+    // And should show more slots than the old 36-hour window (12 × 3h)
+    expect(calls[0].times.length).toBeGreaterThan(12);
   });
 
   it('starts from current time, not midnight, in portrait mode', () => {
@@ -291,12 +295,12 @@ describe('renderDisplay slicing', () => {
     expect(firstTime).toBeGreaterThanOrEqual(Date.now() - 3 * 60 * 60 * 1000);
   });
 
-  it('slices ensemble percentile arrays to match 36 h in portrait mode', () => {
+  it('slices ensemble percentile arrays to match the rendered time window in portrait mode', () => {
     const calls = [];
     const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
     ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
-    expect(calls[0].ensTemp.p10).toHaveLength(12);
-    expect(calls[0].ensTemp1h.p50).toHaveLength(36);
+    expect(calls[0].ensTemp.p10).toHaveLength(calls[0].times.length);
+    expect(calls[0].ensTemp1h.p50).toHaveLength(calls[0].times1h.length);
   });
 
   it('keeps full 7-day data in landscape mode (56×3h entries, 168×1h entries)', () => {
@@ -332,6 +336,21 @@ describe('renderDisplay slicing', () => {
     const t3 = new Date(calls[0].times[0]).getTime();
     const t1 = new Date(calls[0].times1h[0]).getTime();
     expect(t3).toBe(t1);
+  });
+
+  it('passes a positive numeric portraitColW as third arg to renderAll in portrait mode', () => {
+    const colWs = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d, ic, colW) => colWs.push(colW) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(colWs[0]).toBeTypeOf('number');
+    expect(colWs[0]).toBeGreaterThan(0);
+  });
+
+  it('passes null portraitColW to renderAll in landscape mode', () => {
+    const colWs = [];
+    const { ctx } = loadApp({ portrait: false, renderAllSpy: (d, ic, colW) => colWs.push(colW) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(colWs[0]).toBeNull();
   });
 });
 

--- a/vejr.css
+++ b/vejr.css
@@ -575,24 +575,19 @@ canvas.main-canvas {
   .y-axis-right { display: none; }
 }
 
-/* ── Portrait: horizontally scrollable time axis ── */
+/* ── Portrait: horizontally scrollable canvas area ── */
+/*    Each .chart-canvas-wrap is its own scroll container; JS syncs them.   */
+/*    The .y-axis siblings stay fixed — no sticky needed.                   */
 @media (orientation: portrait) {
-  #time-scroll {
+  .chart-canvas-wrap {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
+    /* Hide scrollbar chrome — scrolling still works via swipe/drag */
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
-  /* Keep y-axis labels pinned to the left/right edges while charts scroll */
-  #time-scroll .y-axis {
-    position: sticky;
-    left: 0;
-    z-index: 5;
-  }
-  #time-scroll .y-axis-right {
-    position: sticky;
-    right: 0;
-    z-index: 5;
-  }
+  .chart-canvas-wrap::-webkit-scrollbar { display: none; }
 }
 
 /* ── Inverted colours (iOS): applied via JS body class (matchMedia works;

--- a/vejr.css
+++ b/vejr.css
@@ -575,6 +575,26 @@ canvas.main-canvas {
   .y-axis-right { display: none; }
 }
 
+/* ── Portrait: horizontally scrollable time axis ── */
+@media (orientation: portrait) {
+  #time-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+  }
+  /* Keep y-axis labels pinned to the left/right edges while charts scroll */
+  #time-scroll .y-axis {
+    position: sticky;
+    left: 0;
+    z-index: 5;
+  }
+  #time-scroll .y-axis-right {
+    position: sticky;
+    right: 0;
+    z-index: 5;
+  }
+}
+
 /* ── Inverted colours (iOS): applied via JS body class (matchMedia works;
       @media (inverted-colors) does not reliably fire in WKWebView) ── */
 

--- a/vejr.html
+++ b/vejr.html
@@ -77,6 +77,7 @@
       </div>
     </div>
 
+  <div id="time-scroll">
     <!-- Time + icons -->
     <div class="chart-row" id="row-top">
       <div class="y-axis" id="ax-top" style="justify-content:flex-end; font-size:8px; color:#778; padding-bottom:3px;"></div>
@@ -117,6 +118,7 @@
       </div>
       <div class="y-axis-right" style="border-left:none;background:transparent;"></div>
     </div>
+  </div>
 
   </div>
 </div>


### PR DESCRIPTION
## Summary
This PR transforms portrait mode from showing a fixed 36-hour window to displaying the entire remaining forecast in a horizontally scrollable canvas. Users can now swipe through the full forecast timeline on mobile devices, with all four chart rows (time/icons, temperature, wind direction, wind speed) staying perfectly synchronized during scrolling.

## Key Changes

- **Portrait forecast window**: Changed from a hardcoded 36-hour slice to showing all remaining data from the current time to the end of the forecast dataset
- **Scrollable canvas layout**: Added horizontal scroll containers (`.chart-canvas-wrap`) with synchronized scrolling across all four chart rows via new `initPortraitScrollSync()` function
- **Fixed column width**: Introduced `PORTRAIT_COL_W` constant (24px per 3-hour slot) to ensure consistent sizing and alignment in portrait scroll mode
- **Data tracking**: Added `lastRenderedData` variable to track the sliced data passed to `renderAll()`, replacing reliance on `lastData` for hover interactions and tooltips
- **Hover coordinate mapping**: Updated hover listener to account for horizontal scroll position (`scrollLeft`) when calculating tooltip positions in portrait mode
- **Canvas width synchronization**: Modified all draw functions (`drawTopRow`, `drawTemp`, `drawWindDir`, `drawWind`) to accept an optional `totalCssW` parameter, ensuring all four canvases are exactly the same width regardless of data resolution (1h vs 3h), guaranteeing perfect time-axis alignment during scrolling
- **Test updates**: Updated portrait mode tests to verify full-forecast rendering instead of 36-hour cap, and added tests for `portraitColW` parameter passing

## Implementation Details

- The `renderDisplay()` function now calculates `totalCssW = d.times.length * PORTRAIT_COL_W` in portrait mode and passes it to all draw functions, creating a single source of truth for canvas dimensions
- Scroll synchronization uses a `syncing` flag to prevent feedback loops when programmatically updating `scrollLeft` on sibling containers
- The HTML structure wraps all four chart rows in a `time-scroll` container to enable coordinated horizontal scrolling
- CSS hides native scrollbars while preserving touch/swipe functionality via `-webkit-overflow-scrolling: touch` and `overscroll-behavior-x: contain`

https://claude.ai/code/session_01Ak5jPJwifDEuhkBFZSYNnB