### PR TITLE
Make tooltip closable by clicking on it

### DIFF
--- a/app.js
+++ b/app.js
@@ -396,6 +396,7 @@ function hideTooltip() {
   clearCrosshairs();
 }
 function attachHoverListeners() {
+  document.getElementById('hover-tooltip').addEventListener('click', hideTooltip);
   const content = document.getElementById('forecast-content');
   content.addEventListener('mousemove', e => {
     if (!lastRenderedData) return;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -20,6 +20,7 @@ function makeEl(value = '') {
     getContext:  () => ({
       getImageData:  (x, y, w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
       putImageData:  () => {},
+      clearRect:     () => {},
     }),
     width: 0, height: 0,
   };
@@ -56,6 +57,17 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
     _handler: null,
   };
 
+  const tooltipEl = {
+    style: { display: 'none' },
+    _listeners: {},
+    addEventListener(type, fn) { this._listeners[type] = fn; },
+    getContext: () => null,
+    closest: () => null,
+    width: 0, height: 0,
+    value: '', textContent: '',
+    classList: { contains: () => false, add: () => {}, remove: () => {} },
+  };
+
   const ctx = vm.createContext({
     window: {
       location:             { search, href },
@@ -76,8 +88,9 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
     },
     document: {
       getElementById: (id) => {
-        if (id === 'city-input')   return cityInput;
-        if (id === 'model-select') return makeEl('dmi_seamless');
+        if (id === 'city-input')      return cityInput;
+        if (id === 'model-select')    return makeEl('dmi_seamless');
+        if (id === 'hover-tooltip')   return tooltipEl;
         return makeEl();
       },
       querySelectorAll: () => [],
@@ -124,7 +137,7 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
 
   vm.runInContext(APP_SRC, ctx);
 
-  return { ctx, cityInput, mockLocalStorage, geoCalls, replaceStateCalls, invertedMQL };
+  return { ctx, cityInput, mockLocalStorage, geoCalls, replaceStateCalls, invertedMQL, tooltipEl };
 }
 
 // ── decideInitialLocation unit tests ─────────────────────────────────────────
@@ -395,5 +408,21 @@ describe('inverted-colors change listener', () => {
     });
     ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
     expect(calls[0]).toBe(false);
+  });
+});
+
+// ── tooltip close-on-tap ──────────────────────────────────────────────────────
+
+describe('tooltip close-on-tap', () => {
+  it('registers a click listener on the tooltip element at startup', () => {
+    const { tooltipEl } = loadApp();
+    expect(tooltipEl._listeners['click']).toBeTypeOf('function');
+  });
+
+  it('hides the tooltip when the click listener is invoked', () => {
+    const { tooltipEl } = loadApp();
+    tooltipEl.style.display = 'block';
+    tooltipEl._listeners['click']();
+    expect(tooltipEl.style.display).toBe('none');
   });
 });

--- a/vejr.css
+++ b/vejr.css
@@ -158,7 +158,8 @@ canvas.main-canvas {
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 12px;
   color: #e8eef5;
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: pointer;
   min-width: 148px;
   box-shadow: 0 4px 16px rgba(0,0,0,0.45);
   line-height: 1.55;


### PR DESCRIPTION
## Summary
This PR makes the hover tooltip interactive by allowing users to close it by clicking on it, improving the UX when the tooltip appears unexpectedly or needs to be dismissed.

## Key Changes
- **app.js**: Added click event listener to the tooltip element that triggers the `hideTooltip()` function when clicked
- **vejr.css**: Changed tooltip `pointer-events` from `none` to `auto` to make it clickable, and added `cursor: pointer` to indicate interactivity
- **tests/app.test.js**: 
  - Added mock tooltip element (`tooltipEl`) to test setup with event listener tracking
  - Added `clearRect` method to canvas mock context
  - Added test suite verifying that the click listener is registered on startup and properly hides the tooltip when invoked

## Implementation Details
The tooltip now registers a click handler during initialization via `attachHoverListeners()`. When clicked, it calls `hideTooltip()` which clears the tooltip display and any associated visual elements (crosshairs). The CSS changes enable the tooltip to receive click events and provide visual feedback with a pointer cursor.

https://claude.ai/code/session_012SFsqwQxBiRaSMybNeeEyu