### PR TITLE
Portrait mode: show current day at finest available time resolution (1h icons)

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,24 +183,54 @@ function slicePercentilesFrom(obj, start, n) {
 }
 
 /**
+ * Compute CSS x-center positions for each 1h data point on the variable-resolution
+ * display grid.  Each display slot has width portraitColW px; a 1h point that falls
+ * at offset t within a slot of duration D gets centered at:
+ *   x = (slotIndex + (t + 0.5h) / D) * portraitColW
+ * Returns { xMap1h, xFrac1h, slotIdx1h } — parallel arrays of length times1h.length.
+ */
+function computeXMap1h(times1h, displayTimes, portraitColW) {
+  const n1h  = times1h.length;
+  const nDsp = displayTimes.length;
+  const totalCssW = nDsp * portraitColW;
+  const dspMs = displayTimes.map(t => new Date(t).getTime());
+  const HALF_H = 1800000; // 0.5 h in ms
+  const xMap = [], xFrac = [], slotIdx = [];
+  let j = 0;
+  for (let k = 0; k < n1h; k++) {
+    const tk = new Date(times1h[k]).getTime();
+    while (j < nDsp - 1 && dspMs[j + 1] <= tk) j++;
+    const slotDur = j < nDsp - 1
+      ? dspMs[j + 1] - dspMs[j]
+      : (j > 0 ? dspMs[j] - dspMs[j - 1] : 3600000);
+    const x = (j + (tk - dspMs[j] + HALF_H) / slotDur) * portraitColW;
+    xMap.push(x);
+    xFrac.push(x / totalCssW);
+    slotIdx.push(j);
+  }
+  return { xMap1h: xMap, xFrac1h: xFrac, slotIdx1h: slotIdx };
+}
+
+/**
  * Build a variable-resolution display series for portrait mode.
- * Resolution decreases with distance in time from now:
- *   0–24 h  → 1-hour slots   (finest, today)
- *   24–48 h → 3-hour slots   (tomorrow)
- *   48 h+   → 6-hour slots   (days 3-7)
+ * Base resolution decreases with distance from now; nighttime slots are
+ * additionally coarsened by 3× (capped at 6h) so nights compress naturally:
+ *   0–24 h  daytime  → 1h  |  nighttime → 3h
+ *   24–48 h daytime  → 3h  |  nighttime → 6h
+ *   48 h+            → 6h  (always, day or night)
  *
  * For coarse slots the icon/direction is picked from whichever hour in the
- * window is most "daytime" (prefers midday, avoids night). The axis label
- * uses the scheduled step-aligned start time so day dividers land correctly.
+ * window is most "daytime" (prefers midday, avoids night).
  *
- * The returned object exposes both naming conventions (times/times1h, dirs/dirs1h,
- * codes/codes1h, winds/winds1h, precips/precips1h) so renderAll() works without
- * any changes.
+ * The returned object keeps the display series (times/codes/dirs/precips/winds,
+ * length = N_display) separate from the full 1h arrays (times1h/temps1h/etc.,
+ * length = N_1h).  xMap1h / xFrac1h map each 1h point to its CSS x-center on
+ * the display grid so curves can be drawn at full resolution.
  */
 function buildPortraitSeries(s) {
   const t0 = new Date(s.times1h[0]).getTime();
   const times = [], codes = [], dirs = [];
-  const temps = [], precips = [], gusts = [], winds = [];
+  const precips = [], winds = [];
   const hasEns = s.ensTemp1h != null;
   const ensTemp = { p10: [], p50: [], p90: [] };
   const ensWind = { p10: [], p50: [], p90: [] };
@@ -210,7 +240,10 @@ function buildPortraitSeries(s) {
   let i = 0;
   while (i < s.times1h.length) {
     const hoursAhead = (new Date(s.times1h[i]).getTime() - t0) / 3600000;
-    const step = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : 6;
+    const h = new Date(s.times1h[i]).getHours();
+    const night = typeof isNight === 'function' ? isNight(s.times1h[i]) : (h < 6 || h >= 20);
+    const baseStep = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : 6;
+    const step = Math.min(6, night ? baseStep * 3 : baseStep);
 
     // For coarse steps pick the slot in [i, i+step) that is most daytime.
     let best = i;
@@ -218,9 +251,9 @@ function buildPortraitSeries(s) {
       let bestScore = -Infinity;
       const end = Math.min(i + step, s.times1h.length);
       for (let j = i; j < end; j++) {
-        const h = new Date(s.times1h[j]).getHours();
-        const night = typeof isNight === 'function' ? isNight(s.times1h[j]) : (h < 6 || h >= 20);
-        const score = (night ? 0 : 100) - Math.abs(h - 12);
+        const hj = new Date(s.times1h[j]).getHours();
+        const nj = typeof isNight === 'function' ? isNight(s.times1h[j]) : (hj < 6 || hj >= 20);
+        const score = (nj ? 0 : 100) - Math.abs(hj - 12);
         if (score > bestScore) { bestScore = score; best = j; }
       }
     }
@@ -231,9 +264,7 @@ function buildPortraitSeries(s) {
     codes.push(s.codes1h ? s.codes1h[best] : null);
     dirs.push(s.dirs1h ? s.dirs1h[best]
                        : s.dirs[Math.min(Math.round(best / 3), s.dirs.length - 1)]);
-    temps.push(s.temps1h[best]);
     precips.push(s.precips1h[best]);
-    gusts.push(s.gusts1h[best]);
     winds.push(s.winds1h[best]);
     // Down-sample ensemble percentile bands by picking the best-slot value.
     if (hasEns) {
@@ -248,20 +279,34 @@ function buildPortraitSeries(s) {
     i += step;
   }
 
-  // Both naming conventions point to the same arrays so renderAll needs no changes.
+  // Compute x-positions mapping each 1h point onto the variable-resolution grid.
+  const { xMap1h, xFrac1h, slotIdx1h } = computeXMap1h(s.times1h, times, PORTRAIT_COL_W);
+
   return {
-    times, times1h: times,
-    codes, codes1h: codes,
-    dirs,  dirs1h:  dirs,
-    temps1h: temps,
-    precips, precips1h: precips,
-    gusts1h: gusts,
-    winds, winds1h: winds,
-    // Ensemble percentile bands down-sampled to match the display series resolution.
-    ensTemp:   hasEns ? ensTemp   : null, ensTemp1h:   hasEns ? ensTemp   : null,
-    ensWind:   hasEns ? ensWind   : null, ensWind1h:   hasEns ? ensWind   : null,
-    ensGust:   hasEns ? ensGust   : null, ensGust1h:   hasEns ? ensGust   : null,
-    ensPrecip: hasEns ? ensPrecip : null, ensPrecip1h: hasEns ? ensPrecip : null,
+    // Display series (N_display): icons, arrows, axis ticks, kite highlights.
+    times, codes, dirs,
+    precips,  // representative precip per display slot (for bars in drawTemp)
+    winds,    // representative wind per display slot (for kite highlights in drawWind)
+    ensTemp:   hasEns ? ensTemp   : null,
+    ensWind:   hasEns ? ensWind   : null,
+    ensGust:   hasEns ? ensGust   : null,
+    ensPrecip: hasEns ? ensPrecip : null,
+
+    // Full 1h arrays (N_1h): smooth curves and precise tooltip values.
+    times1h:     s.times1h,
+    temps1h:     s.temps1h,
+    precips1h:   s.precips1h,
+    gusts1h:     s.gusts1h,
+    winds1h:     s.winds1h,
+    codes1h:     s.codes1h,
+    dirs1h:      s.dirs1h,
+    ensTemp1h:   s.ensTemp1h,
+    ensWind1h:   s.ensWind1h,
+    ensGust1h:   s.ensGust1h,
+    ensPrecip1h: s.ensPrecip1h,
+
+    // x-position mapping: each 1h point → CSS x-center on the display grid.
+    xMap1h, xFrac1h, slotIdx1h,
   };
 }
 
@@ -349,12 +394,18 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const ensGustMax    = d.ensGust1h ? Math.max(...d.ensGust1h.p90.filter(v => v != null)) : 0;
   const maxW          = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
   const windDotY      = WIND_padT + (1 - d.winds1h[idx1h] / maxW) * WIND_chartH;
-  // xh-dir snaps to 3hr columns; xh-temp and xh-wind snap to 1hr columns.
-  // xh-top uses 1hr columns when codes1h is present (portrait mode), else 3hr.
+  // When xFrac1h is present (portrait+xMap mode), curve canvases use the precise
+  // per-point fraction; icon/arrow rows snap to the display-slot centre (fracX3h).
   const fracX3h = (idx3h + 0.5) / d.times.length;
   const fracX1h = (idx1h + 0.5) / d.times1h.length;
+  const fracX1h_curve = d.xFrac1h ? d.xFrac1h[idx1h] : fracX1h;
   const DOT_Y   = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
-  const FRAC    = { 'xh-top': d.codes1h ? fracX1h : fracX3h, 'xh-temp': fracX1h, 'xh-dir': fracX3h, 'xh-wind': fracX1h };
+  const FRAC    = {
+    'xh-top':  d.xFrac1h ? fracX3h : (d.codes1h ? fracX1h : fracX3h),
+    'xh-temp': fracX1h_curve,
+    'xh-dir':  fracX3h,
+    'xh-wind': fracX1h_curve,
+  };
   XH_CANVASES.forEach(id => {
     const c   = document.getElementById(id);
     const ref = document.getElementById(XH_PAIR[id]);
@@ -414,8 +465,8 @@ function showTooltip(idx1h, idx3h) {
   const prec = d.precips1h[idx1h];
   const wind = d.winds1h[idx1h];
   const gust = Math.max(d.gusts1h[idx1h], wind);
-  // Icon/direction from best-resolution arrays available
-  const dir  = d.dirs[idx3h];
+  // Icon/direction: use 1h arrays (precise) when available, else display-series.
+  const dir  = d.dirs1h ? d.dirs1h[idx1h] : d.dirs[idx3h];
   const code = d.codes1h ? d.codes1h[idx1h] : d.codes[idx3h];
   const windCol = windColorStr(wind);
   const gustCol = windColorStr(gust);
@@ -525,8 +576,25 @@ function attachHoverListeners() {
     const fracX    = Math.max(0, Math.min(1, relX / span));
     const n1h      = lastRenderedData.times1h.length;
     const n3h      = lastRenderedData.times.length;
-    const idx1h    = Math.min(n1h - 1, Math.floor(fracX * n1h));
-    const idx3h    = Math.min(n3h - 1, Math.floor(fracX * n3h));
+    let idx1h, idx3h;
+    if (lastRenderedData.xFrac1h) {
+      // Variable-resolution portrait: binary-search for nearest 1h point.
+      const xf = lastRenderedData.xFrac1h;
+      let lo = 0, hi = n1h - 1;
+      while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (xf[mid] <= fracX) lo = mid; else hi = mid - 1;
+      }
+      if (lo < n1h - 1 && Math.abs(xf[lo + 1] - fracX) < Math.abs(xf[lo] - fracX)) lo++;
+      idx1h = lo;
+      // slotIdx1h maps each 1h point to its display slot → valid idx3h.
+      idx3h = lastRenderedData.slotIdx1h
+        ? Math.min(lastRenderedData.slotIdx1h[lo], n3h - 1)
+        : Math.min(lo, n3h - 1);
+    } else {
+      idx1h = Math.min(n1h - 1, Math.floor(fracX * n1h));
+      idx3h = Math.min(n3h - 1, Math.floor(fracX * n3h));
+    }
     drawCrosshairs(fracX, idx1h, idx3h);
     showTooltip(idx1h, idx3h);
   });

--- a/app.js
+++ b/app.js
@@ -174,7 +174,7 @@ async function load(cityName, model) {
    so the current day is shown at the finest available time resolution,
    and the user can swipe to travel through time.
 ══════════════════════════════════════════════════ */
-const PORTRAIT_COL_W = 24; // px per 1-hour slot in portrait scroll mode
+const PORTRAIT_COL_W = 36; // px per 1-hour slot in portrait scroll mode (= ICON_H, icons fit exactly)
 
 function slicePercentilesFrom(obj, start, n) {
   if (!obj) return null;

--- a/app.js
+++ b/app.js
@@ -45,8 +45,8 @@ async function load(cityName, model) {
       });
     }
     const times=[],temps=[],precips=[],gusts=[],winds=[],dirs=[],codes=[];
-    // 1-hour resolution arrays for smooth curves (temp, wind speed/gust, precip)
-    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[];
+    // 1-hour resolution arrays for smooth curves (temp, wind speed/gust, precip) and icons
+    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[],codes1h=[];
     const totalH=FORECAST_DAYS*24;
     for(let i=0;i<Math.min(totalH,H.time.length);i+=STEP){
       times.push(H.time[i]);
@@ -71,6 +71,11 @@ async function load(cityName, model) {
       winds1h.push(H.windspeed_10m[i]);
       const rawGust1h = H.windgusts_10m[i];
       gusts1h.push(rawGust1h != null ? rawGust1h : H.windspeed_10m[i]);
+      // Weather codes at 1h resolution (portrait mode shows finest available icons)
+      const dmiCode1h  = H.weathercode[i];
+      const iconCode1h = iconCodes ? (iconCodes[i] ?? dmiCode1h) : dmiCode1h;
+      codes1h.push((iconCodes && dmiCode1h >= 80 && dmiCode1h <= 82 && iconCode1h >= 95)
+        ? iconCode1h : dmiCode1h);
     }
     const MODEL_LABEL = {
       'best_match':          'Auto',
@@ -144,7 +149,7 @@ async function load(cityName, model) {
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
-      times1h, temps1h, precips1h, gusts1h, winds1h,
+      times1h, temps1h, precips1h, gusts1h, winds1h, codes1h,
       ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
     };
     // Double rAF ensures layout is complete before measuring canvas width
@@ -165,10 +170,11 @@ async function load(cityName, model) {
 /* ══════════════════════════════════════════════════
    PORTRAIT-AWARE RENDERING
    In portrait mode the full remaining forecast is shown in a scrollable
-   canvas — each 3-hour slot is PORTRAIT_COL_W px wide so one icon fits
-   per slot, and the user can swipe to travel through time.
+   canvas — each 1-hour slot is PORTRAIT_COL_W px wide (one icon per slot)
+   so the current day is shown at the finest available time resolution,
+   and the user can swipe to travel through time.
 ══════════════════════════════════════════════════ */
-const PORTRAIT_COL_W = 24; // px per 3-hour slot in portrait scroll mode
+const PORTRAIT_COL_W = 24; // px per 1-hour slot in portrait scroll mode
 
 function slicePercentilesFrom(obj, start, n) {
   if (!obj) return null;
@@ -202,6 +208,7 @@ function renderDisplay(d) {
     ensTemp:  slicePercentilesFrom(d.ensTemp,  s3, n3h), ensWind:  slicePercentilesFrom(d.ensWind,  s3, n3h),
     ensGust:  slicePercentilesFrom(d.ensGust,  s3, n3h), ensPrecip: slicePercentilesFrom(d.ensPrecip, s3, n3h),
     times1h:  d.times1h.slice(s1, s1 + n1h),  temps1h:  d.temps1h.slice(s1, s1 + n1h),
+    codes1h:  d.codes1h ? d.codes1h.slice(s1, s1 + n1h) : null,
     precips1h: d.precips1h.slice(s1, s1 + n1h), gusts1h: d.gusts1h.slice(s1, s1 + n1h),
     winds1h:  d.winds1h.slice(s1, s1 + n1h),
     ensTemp1h:  slicePercentilesFrom(d.ensTemp1h,  s1, n1h), ensWind1h:  slicePercentilesFrom(d.ensWind1h,  s1, n1h),
@@ -256,11 +263,12 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const ensGustMax    = d.ensGust1h ? Math.max(...d.ensGust1h.p90.filter(v => v != null)) : 0;
   const maxW          = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
   const windDotY      = WIND_padT + (1 - d.winds1h[idx1h] / maxW) * WIND_chartH;
-  // xh-top and xh-dir snap to 3hr columns; xh-temp and xh-wind snap to 1hr columns
+  // xh-dir snaps to 3hr columns; xh-temp and xh-wind snap to 1hr columns.
+  // xh-top uses 1hr columns when codes1h is present (portrait mode), else 3hr.
   const fracX3h = (idx3h + 0.5) / d.times.length;
   const fracX1h = (idx1h + 0.5) / d.times1h.length;
   const DOT_Y   = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
-  const FRAC    = { 'xh-top': fracX3h, 'xh-temp': fracX1h, 'xh-dir': fracX3h, 'xh-wind': fracX1h };
+  const FRAC    = { 'xh-top': d.codes1h ? fracX1h : fracX3h, 'xh-temp': fracX1h, 'xh-dir': fracX3h, 'xh-wind': fracX1h };
   XH_CANVASES.forEach(id => {
     const c   = document.getElementById(id);
     const ref = document.getElementById(XH_PAIR[id]);
@@ -320,9 +328,9 @@ function showTooltip(idx1h, idx3h) {
   const prec = d.precips1h[idx1h];
   const wind = d.winds1h[idx1h];
   const gust = Math.max(d.gusts1h[idx1h], wind);
-  // Icon/direction from 3hr arrays
+  // Icon/direction from best-resolution arrays available
   const dir  = d.dirs[idx3h];
-  const code = d.codes[idx3h];
+  const code = d.codes1h ? d.codes1h[idx1h] : d.codes[idx3h];
   const windCol = windColorStr(wind);
   const gustCol = windColorStr(gust);
   const tp10 = d.ensTemp1h   ? d.ensTemp1h.p10[idx1h]   : null;
@@ -1053,7 +1061,7 @@ async function loadAtCoords(lat, lon, model) {
       });
     }
     const times=[],temps=[],precips=[],gusts=[],winds=[],dirs=[],codes=[];
-    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[];
+    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[],codes1h=[];
     const totalH = FORECAST_DAYS * 24;
     for (let i = 0; i < Math.min(totalH, H.time.length); i += STEP) {
       times.push(H.time[i]);
@@ -1076,6 +1084,11 @@ async function loadAtCoords(lat, lon, model) {
       winds1h.push(H.windspeed_10m[i]);
       const rawGust1h = H.windgusts_10m[i];
       gusts1h.push(rawGust1h != null ? rawGust1h : H.windspeed_10m[i]);
+      // Weather codes at 1h resolution (portrait mode shows finest available icons)
+      const dmiCode1h  = H.weathercode[i];
+      const iconCode1h = iconCodes ? (iconCodes[i] ?? dmiCode1h) : dmiCode1h;
+      codes1h.push((iconCodes && dmiCode1h >= 80 && dmiCode1h <= 82 && iconCode1h >= 95)
+        ? iconCode1h : dmiCode1h);
     }
     const MODEL_LABEL = {
       'best_match':          'Auto',      'dmi_seamless':        'DMI HARMONIE',
@@ -1129,7 +1142,7 @@ async function loadAtCoords(lat, lon, model) {
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
-      times1h, temps1h, precips1h, gusts1h, winds1h,
+      times1h, temps1h, precips1h, gusts1h, winds1h, codes1h,
       ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
     };
     requestAnimationFrame(() => requestAnimationFrame(() => renderDisplay(lastData)));

--- a/app.js
+++ b/app.js
@@ -230,7 +230,7 @@ function computeXMap1h(times1h, displayTimes, portraitColW) {
 function buildPortraitSeries(s) {
   const t0 = new Date(s.times1h[0]).getTime();
   const times = [], codes = [], dirs = [];
-  const precips = [], winds = [];
+  const precips = [], winds = [], temps = [], gusts = [];
   const hasEns = s.ensTemp1h != null;
   const ensTemp = { p10: [], p50: [], p90: [] };
   const ensWind = { p10: [], p50: [], p90: [] };
@@ -266,6 +266,8 @@ function buildPortraitSeries(s) {
                        : s.dirs[Math.min(Math.round(best / 3), s.dirs.length - 1)]);
     precips.push(s.precips1h[best]);
     winds.push(s.winds1h[best]);
+    temps.push(s.temps1h[best]);
+    gusts.push(s.gusts1h[best]);
     // Down-sample ensemble percentile bands by picking the best-slot value.
     if (hasEns) {
       ['p10', 'p50', 'p90'].forEach(k => {
@@ -283,9 +285,11 @@ function buildPortraitSeries(s) {
   const { xMap1h, xFrac1h, slotIdx1h } = computeXMap1h(s.times1h, times, PORTRAIT_COL_W);
 
   return {
-    // Display series (N_display): icons, arrows, axis ticks, kite highlights.
+    // Display series (N_display): icons, arrows, axis ticks, kite highlights, curves.
     times, codes, dirs,
+    temps,    // representative temperature per display slot (for temp curve in portrait)
     precips,  // representative precip per display slot (for bars in drawTemp)
+    gusts,    // representative gust per display slot (for wind curve in portrait)
     winds,    // representative wind per display slot (for kite highlights in drawWind)
     ensTemp:   hasEns ? ensTemp   : null,
     ensWind:   hasEns ? ensWind   : null,
@@ -380,31 +384,35 @@ function clearCrosshairs() {
 function drawCrosshairs(fracX, idx1h, idx3h) {
   if (!lastRenderedData) return;
   const d = lastRenderedData;
-  // Re-derive the same y-mappings used by the draw functions
+  const portrait = !!d.xFrac1h;
+  // Re-derive the same y-mappings used by the draw functions.
+  // In portrait all charts use the display series; in landscape curves use 1h data.
+  const temps_arr = portrait ? d.temps   : d.temps1h;
+  const winds_arr = portrait ? d.winds   : d.winds1h;
+  const gusts_arr = portrait ? d.gusts   : d.gusts1h;
+  const ens_gust  = portrait ? d.ensGust : d.ensGust1h;
+  const idx       = portrait ? idx3h     : idx1h;
   const TEMP_cssH = 130, TEMP_padT = 8, TEMP_padB = 8;
   const TEMP_ch   = TEMP_cssH - TEMP_padT - TEMP_padB;
-  let tmin = Math.floor(Math.min(...d.temps1h) / 5) * 5;
-  let tmax = Math.ceil( Math.max(...d.temps1h) / 5) * 5;
+  let tmin = Math.floor(Math.min(...temps_arr) / 5) * 5;
+  let tmax = Math.ceil( Math.max(...temps_arr) / 5) * 5;
   if (tmax - tmin < 15) { const mid = (tmin + tmax) / 2; tmin = Math.floor((mid - 7.5) / 5) * 5; tmax = tmin + 15; }
   const tRange   = tmax - tmin;
-  const tempDotY = TEMP_padT + (1 - (d.temps1h[idx1h] - tmin) / tRange) * TEMP_ch;
+  const tempDotY = TEMP_padT + (1 - (temps_arr[idx] - tmin) / tRange) * TEMP_ch;
   const WIND_H = 130, WIND_KITE_H = 24, WIND_padT = WIND_KITE_H + 4;
-  const WIND_chartH   = WIND_H - WIND_padT;
-  const safeGusts     = d.gusts1h.map((g, i) => Math.max(g, d.winds1h[i]));
-  const ensGustMax    = d.ensGust1h ? Math.max(...d.ensGust1h.p90.filter(v => v != null)) : 0;
-  const maxW          = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
-  const windDotY      = WIND_padT + (1 - d.winds1h[idx1h] / maxW) * WIND_chartH;
-  // When xFrac1h is present (portrait+xMap mode), curve canvases use the precise
-  // per-point fraction; icon/arrow rows snap to the display-slot centre (fracX3h).
+  const WIND_chartH = WIND_H - WIND_padT;
+  const safeGusts   = gusts_arr.map((g, i) => Math.max(g, winds_arr[i]));
+  const ensGustMax  = ens_gust ? Math.max(...ens_gust.p90.filter(v => v != null)) : 0;
+  const maxW        = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
+  const windDotY    = WIND_padT + (1 - winds_arr[idx] / maxW) * WIND_chartH;
   const fracX3h = (idx3h + 0.5) / d.times.length;
   const fracX1h = (idx1h + 0.5) / d.times1h.length;
-  const fracX1h_curve = d.xFrac1h ? d.xFrac1h[idx1h] : fracX1h;
   const DOT_Y   = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
   const FRAC    = {
-    'xh-top':  d.xFrac1h ? fracX3h : (d.codes1h ? fracX1h : fracX3h),
-    'xh-temp': fracX1h_curve,
+    'xh-top':  portrait ? fracX3h : (d.codes1h ? fracX1h : fracX3h),
+    'xh-temp': portrait ? fracX3h : fracX1h,
     'xh-dir':  fracX3h,
-    'xh-wind': fracX1h_curve,
+    'xh-wind': portrait ? fracX3h : fracX1h,
   };
   XH_CANVASES.forEach(id => {
     const c   = document.getElementById(id);
@@ -430,7 +438,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     ctx.setLineDash([]);
     const dotY = DOT_Y[id];
     if (dotY !== null) {
-      const dotCol = (id === 'xh-temp') ? (d.temps1h[idx1h] >= 0 ? '#cc2200' : '#4488ff') : '#fff';
+      const dotCol = (id === 'xh-temp') ? (temps_arr[idx] >= 0 ? '#cc2200' : '#4488ff') : '#fff';
       ctx.fillStyle   = dotCol;
       ctx.strokeStyle = 'rgba(0,0,0,0.4)';
       ctx.lineWidth   = 1;
@@ -456,28 +464,46 @@ function showTooltip(idx1h, idx3h) {
   if (!lastRenderedData) return;
   const d = lastRenderedData;
   const tip = document.getElementById('hover-tooltip');
-  // Time label from 1hr array for precision
-  const t    = new Date(d.times1h[idx1h]);
-  const day  = DA_DAYS[t.getDay()];
-  const h    = t.getHours().toString().padStart(2,'0');
-  // Curve values from 1hr arrays
-  const temp = d.temps1h[idx1h];
-  const prec = d.precips1h[idx1h];
-  const wind = d.winds1h[idx1h];
-  const gust = Math.max(d.gusts1h[idx1h], wind);
-  // Icon/direction: use 1h arrays (precise) when available, else display-series.
-  const dir  = d.dirs1h ? d.dirs1h[idx1h] : d.dirs[idx3h];
-  const code = d.codes1h ? d.codes1h[idx1h] : d.codes[idx3h];
-  const windCol = windColorStr(wind);
-  const gustCol = windColorStr(gust);
-  const tp10 = d.ensTemp1h   ? d.ensTemp1h.p10[idx1h]   : null;
-  const tp90 = d.ensTemp1h   ? d.ensTemp1h.p90[idx1h]   : null;
-  const wp10 = d.ensWind1h   ? d.ensWind1h.p10[idx1h]   : null;
-  const wp90 = d.ensWind1h   ? d.ensWind1h.p90[idx1h]   : null;
-  const gp10 = d.ensGust1h   ? (d.ensGust1h.p10[idx1h]   ?? null) : null;
-  const gp90 = d.ensGust1h   ? (d.ensGust1h.p90[idx1h]   ?? null) : null;
-  const pp10 = d.ensPrecip1h ? d.ensPrecip1h.p10[idx1h] : null;
-  const pp90 = d.ensPrecip1h ? d.ensPrecip1h.p90[idx1h] : null;
+  const portrait = !!d.xFrac1h;
+  let timeStr, temp, prec, wind, gust, dir, code, tp10, tp90, wp10, wp90, gp10, gp90, pp10, pp90;
+  if (portrait) {
+    // Portrait: all values from display series (same zoom as icon row).
+    timeStr = d.times[idx3h];
+    temp    = d.temps[idx3h];
+    prec    = d.precips[idx3h];
+    wind    = d.winds[idx3h];
+    gust    = Math.max(d.gusts[idx3h], wind);
+    dir     = d.dirs[idx3h];
+    code    = d.codes[idx3h];
+    tp10    = d.ensTemp   ? d.ensTemp.p10[idx3h]   : null;
+    tp90    = d.ensTemp   ? d.ensTemp.p90[idx3h]   : null;
+    wp10    = d.ensWind   ? d.ensWind.p10[idx3h]   : null;
+    wp90    = d.ensWind   ? d.ensWind.p90[idx3h]   : null;
+    gp10    = d.ensGust   ? (d.ensGust.p10[idx3h]  ?? null) : null;
+    gp90    = d.ensGust   ? (d.ensGust.p90[idx3h]  ?? null) : null;
+    pp10    = d.ensPrecip ? d.ensPrecip.p10[idx3h] : null;
+    pp90    = d.ensPrecip ? d.ensPrecip.p90[idx3h] : null;
+  } else {
+    // Landscape: full 1h resolution.
+    timeStr = d.times1h[idx1h];
+    temp    = d.temps1h[idx1h];
+    prec    = d.precips1h[idx1h];
+    wind    = d.winds1h[idx1h];
+    gust    = Math.max(d.gusts1h[idx1h], wind);
+    dir     = d.dirs1h ? d.dirs1h[idx1h] : d.dirs[idx3h];
+    code    = d.codes1h ? d.codes1h[idx1h] : d.codes[idx3h];
+    tp10    = d.ensTemp1h   ? d.ensTemp1h.p10[idx1h]   : null;
+    tp90    = d.ensTemp1h   ? d.ensTemp1h.p90[idx1h]   : null;
+    wp10    = d.ensWind1h   ? d.ensWind1h.p10[idx1h]   : null;
+    wp90    = d.ensWind1h   ? d.ensWind1h.p90[idx1h]   : null;
+    gp10    = d.ensGust1h   ? (d.ensGust1h.p10[idx1h]  ?? null) : null;
+    gp90    = d.ensGust1h   ? (d.ensGust1h.p90[idx1h]  ?? null) : null;
+    pp10    = d.ensPrecip1h ? d.ensPrecip1h.p10[idx1h] : null;
+    pp90    = d.ensPrecip1h ? d.ensPrecip1h.p90[idx1h] : null;
+  }
+  const t   = new Date(timeStr);
+  const day = DA_DAYS[t.getDay()];
+  const h   = t.getHours().toString().padStart(2,'0');
   const fmt  = (v, deg) => (v >= 0 ? '+' : '') + v.toFixed(1) + (deg ? '°C' : ' m/s');
   const tempUncRow   = (tp10 != null && tp90 != null)
     ? `<div class="tt-row"><span class="tt-label">P10–P90</span><span class="tt-val" style="color:#bb8866;font-size:10px">${fmt(tp10,true)} → ${fmt(tp90,true)}</span></div>` : '';
@@ -488,7 +514,7 @@ function showTooltip(idx1h, idx3h) {
   const precipUncRow = (pp10 != null && pp90 != null)
     ? `<div class="tt-row"><span class="tt-label">P10–P90</span><span class="tt-val" style="color:#6aaee8;font-size:10px">${pp10.toFixed(1)} → ${pp90.toFixed(1)} mm</span></div>` : '';
   const desc    = WMO_DESC[code] || 'Unknown';
-  const kiteRow = isKiteOptimal(wind, dir, d.times1h[idx1h])
+  const kiteRow = isKiteOptimal(wind, dir, timeStr)
     ? `<div style="color:#00c8a0;font-size:10px;font-weight:700;margin-bottom:4px;letter-spacing:0.3px;">🪁 Optimal kitesurfing wind</div>` : '';
   // DMI observed wind nearest to this time slot (within 30 min)
   let obsRow = '';
@@ -514,7 +540,7 @@ function showTooltip(idx1h, idx3h) {
     <div class="tt-row" style="margin-bottom:4px;align-items:center;">
       <div style="position:relative;flex:0 0 32px;width:32px;height:32px;">
         <canvas id="tt-icon-canvas" width="32" height="32" style="display:block;"></canvas>
-        ${isKiteOptimal(wind, dir, d.times1h[idx1h]) ? '<span style="position:absolute;bottom:-3px;right:-5px;font-size:14px;line-height:1;">🪁</span>' : ''}
+        ${isKiteOptimal(wind, dir, timeStr) ? '<span style="position:absolute;bottom:-3px;right:-5px;font-size:14px;line-height:1;">🪁</span>' : ''}
       </div>
       <span class="tt-val" style="font-size:11px;color:#cde">${desc}</span>
     </div>
@@ -554,7 +580,7 @@ function showTooltip(idx1h, idx3h) {
     iconCanvas.style.height = sz + 'px';
     const ictx = iconCanvas.getContext('2d');
     ictx.scale(dpr, dpr);
-    dmiIcon(ictx, wmoType(code, d.times1h[idx1h]), sz / 2, sz / 2, sz, prec, code);
+    dmiIcon(ictx, wmoType(code, timeStr), sz / 2, sz / 2, sz, prec, code);
   }
 }
 function hideTooltip() {
@@ -577,23 +603,12 @@ function attachHoverListeners() {
     const n1h      = lastRenderedData.times1h.length;
     const n3h      = lastRenderedData.times.length;
     let idx1h, idx3h;
+    idx3h = Math.min(n3h - 1, Math.floor(fracX * n3h));
     if (lastRenderedData.xFrac1h) {
-      // Variable-resolution portrait: binary-search for nearest 1h point.
-      const xf = lastRenderedData.xFrac1h;
-      let lo = 0, hi = n1h - 1;
-      while (lo < hi) {
-        const mid = (lo + hi + 1) >> 1;
-        if (xf[mid] <= fracX) lo = mid; else hi = mid - 1;
-      }
-      if (lo < n1h - 1 && Math.abs(xf[lo + 1] - fracX) < Math.abs(xf[lo] - fracX)) lo++;
-      idx1h = lo;
-      // slotIdx1h maps each 1h point to its display slot → valid idx3h.
-      idx3h = lastRenderedData.slotIdx1h
-        ? Math.min(lastRenderedData.slotIdx1h[lo], n3h - 1)
-        : Math.min(lo, n3h - 1);
+      // Portrait: display series drives all charts; idx1h is unused.
+      idx1h = idx3h;
     } else {
       idx1h = Math.min(n1h - 1, Math.floor(fracX * n1h));
-      idx3h = Math.min(n3h - 1, Math.floor(fracX * n3h));
     }
     drawCrosshairs(fracX, idx1h, idx3h);
     showTooltip(idx1h, idx3h);
@@ -609,7 +624,19 @@ attachHoverListeners();
 ══════════════════════════════════════════════════ */
 function initPortraitScrollSync() {
   const wraps = document.querySelectorAll ? [...document.querySelectorAll('.chart-canvas-wrap')] : [];
+  if (!wraps.length) return;
+
   let syncing = false;
+
+  function syncAll(left) {
+    syncing = true;
+    const max = wraps[0].scrollWidth - wraps[0].clientWidth;
+    const clamped = Math.max(0, Math.min(max, left));
+    wraps.forEach(w => { w.scrollLeft = clamped; });
+    syncing = false;
+  }
+
+  // Keep all wraps in step on native scroll (mouse wheel, keyboard, trackpad).
   wraps.forEach(wrap => {
     wrap.addEventListener('scroll', () => {
       if (syncing) return;
@@ -617,6 +644,54 @@ function initPortraitScrollSync() {
       const left = wrap.scrollLeft;
       wraps.forEach(w => { if (w !== wrap) w.scrollLeft = left; });
       syncing = false;
+    }, { passive: true });
+  });
+
+  // Touch momentum: intercept horizontal swipes, apply velocity after lift.
+  let rafId = null;
+  let velX = 0, lastX = 0, lastT = 0, startY = 0;
+  let horizontal = null;
+  const DECEL = 0.92;
+
+  wraps.forEach(wrap => {
+    wrap.addEventListener('touchstart', e => {
+      if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+      velX = 0; horizontal = null;
+      lastX = e.touches[0].clientX;
+      lastT = performance.now();
+      startY = e.touches[0].clientY;
+    }, { passive: true });
+
+    wrap.addEventListener('touchmove', e => {
+      const cx = e.touches[0].clientX;
+      const cy = e.touches[0].clientY;
+      const dx = cx - lastX;
+      const dy = cy - startY;
+      if (horizontal === null && (Math.abs(dx) > 5 || Math.abs(dy) > 5))
+        horizontal = Math.abs(dx) >= Math.abs(dy);
+      if (!horizontal) return;
+      e.preventDefault();
+      const now = performance.now();
+      const dt  = Math.max(1, now - lastT);
+      // velX is pixels-per-16ms-frame; positive = scrolling right (scrollLeft increases).
+      velX = -(dx / dt) * 16;
+      syncAll(wrap.scrollLeft - dx);
+      lastX = cx; lastT = now;
+    }, { passive: false });
+
+    wrap.addEventListener('touchend', () => {
+      if (!horizontal) return;
+      (function step() {
+        velX *= DECEL;
+        if (Math.abs(velX) < 0.5) { rafId = null; return; }
+        syncAll(wraps[0].scrollLeft + velX);
+        rafId = requestAnimationFrame(step);
+      })();
+    }, { passive: true });
+
+    wrap.addEventListener('touchcancel', () => {
+      if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+      velX = 0; horizontal = null;
     }, { passive: true });
   });
 }

--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ async function load(cityName, model) {
     }
     const times=[],temps=[],precips=[],gusts=[],winds=[],dirs=[],codes=[];
     // 1-hour resolution arrays for smooth curves (temp, wind speed/gust, precip) and icons
-    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[],codes1h=[];
+    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[],codes1h=[],dirs1h=[];
     const totalH=FORECAST_DAYS*24;
     for(let i=0;i<Math.min(totalH,H.time.length);i+=STEP){
       times.push(H.time[i]);
@@ -76,6 +76,7 @@ async function load(cityName, model) {
       const iconCode1h = iconCodes ? (iconCodes[i] ?? dmiCode1h) : dmiCode1h;
       codes1h.push((iconCodes && dmiCode1h >= 80 && dmiCode1h <= 82 && iconCode1h >= 95)
         ? iconCode1h : dmiCode1h);
+      dirs1h.push(H.winddirection_10m[i]);
     }
     const MODEL_LABEL = {
       'best_match':          'Auto',
@@ -149,7 +150,7 @@ async function load(cityName, model) {
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
-      times1h, temps1h, precips1h, gusts1h, winds1h, codes1h,
+      times1h, temps1h, precips1h, gusts1h, winds1h, codes1h, dirs1h,
       ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
     };
     // Double rAF ensures layout is complete before measuring canvas width
@@ -179,6 +180,89 @@ const PORTRAIT_COL_W = 36; // px per 1-hour slot in portrait scroll mode (= ICON
 function slicePercentilesFrom(obj, start, n) {
   if (!obj) return null;
   return { p10: obj.p10.slice(start, start + n), p50: obj.p50.slice(start, start + n), p90: obj.p90.slice(start, start + n) };
+}
+
+/**
+ * Build a variable-resolution display series for portrait mode.
+ * Resolution decreases with distance in time from now:
+ *   0–24 h  → 1-hour slots   (finest, today)
+ *   24–48 h → 3-hour slots   (tomorrow)
+ *   48 h+   → 6-hour slots   (days 3-7)
+ *
+ * For coarse slots the icon/direction is picked from whichever hour in the
+ * window is most "daytime" (prefers midday, avoids night). The axis label
+ * uses the scheduled step-aligned start time so day dividers land correctly.
+ *
+ * The returned object exposes both naming conventions (times/times1h, dirs/dirs1h,
+ * codes/codes1h, winds/winds1h, precips/precips1h) so renderAll() works without
+ * any changes.
+ */
+function buildPortraitSeries(s) {
+  const t0 = new Date(s.times1h[0]).getTime();
+  const times = [], codes = [], dirs = [];
+  const temps = [], precips = [], gusts = [], winds = [];
+  const hasEns = s.ensTemp1h != null;
+  const ensTemp = { p10: [], p50: [], p90: [] };
+  const ensWind = { p10: [], p50: [], p90: [] };
+  const ensGust = { p10: [], p50: [], p90: [] };
+  const ensPrecip = { p10: [], p50: [], p90: [] };
+
+  let i = 0;
+  while (i < s.times1h.length) {
+    const hoursAhead = (new Date(s.times1h[i]).getTime() - t0) / 3600000;
+    const step = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : 6;
+
+    // For coarse steps pick the slot in [i, i+step) that is most daytime.
+    let best = i;
+    if (step > 1) {
+      let bestScore = -Infinity;
+      const end = Math.min(i + step, s.times1h.length);
+      for (let j = i; j < end; j++) {
+        const h = new Date(s.times1h[j]).getHours();
+        const night = typeof isNight === 'function' ? isNight(s.times1h[j]) : (h < 6 || h >= 20);
+        const score = (night ? 0 : 100) - Math.abs(h - 12);
+        if (score > bestScore) { bestScore = score; best = j; }
+      }
+    }
+
+    // Time label: step-aligned start (so day boundaries land on exact midnight).
+    times.push(s.times1h[i]);
+    // Icon/direction: from the most-daytime slot.
+    codes.push(s.codes1h ? s.codes1h[best] : null);
+    dirs.push(s.dirs1h ? s.dirs1h[best]
+                       : s.dirs[Math.min(Math.round(best / 3), s.dirs.length - 1)]);
+    temps.push(s.temps1h[best]);
+    precips.push(s.precips1h[best]);
+    gusts.push(s.gusts1h[best]);
+    winds.push(s.winds1h[best]);
+    // Down-sample ensemble percentile bands by picking the best-slot value.
+    if (hasEns) {
+      ['p10', 'p50', 'p90'].forEach(k => {
+        ensTemp[k].push(s.ensTemp1h[k][best]);
+        ensWind[k].push(s.ensWind1h[k][best]);
+        ensGust[k].push(s.ensGust1h[k][best]);
+        ensPrecip[k].push(s.ensPrecip1h[k][best]);
+      });
+    }
+
+    i += step;
+  }
+
+  // Both naming conventions point to the same arrays so renderAll needs no changes.
+  return {
+    times, times1h: times,
+    codes, codes1h: codes,
+    dirs,  dirs1h:  dirs,
+    temps1h: temps,
+    precips, precips1h: precips,
+    gusts1h: gusts,
+    winds, winds1h: winds,
+    // Ensemble percentile bands down-sampled to match the display series resolution.
+    ensTemp:   hasEns ? ensTemp   : null, ensTemp1h:   hasEns ? ensTemp   : null,
+    ensWind:   hasEns ? ensWind   : null, ensWind1h:   hasEns ? ensWind   : null,
+    ensGust:   hasEns ? ensGust   : null, ensGust1h:   hasEns ? ensGust   : null,
+    ensPrecip: hasEns ? ensPrecip : null, ensPrecip1h: hasEns ? ensPrecip : null,
+  };
 }
 
 function renderDisplay(d) {
@@ -211,12 +295,14 @@ function renderDisplay(d) {
     codes1h:  d.codes1h ? d.codes1h.slice(s1, s1 + n1h) : null,
     precips1h: d.precips1h.slice(s1, s1 + n1h), gusts1h: d.gusts1h.slice(s1, s1 + n1h),
     winds1h:  d.winds1h.slice(s1, s1 + n1h),
+    dirs1h:   d.dirs1h ? d.dirs1h.slice(s1, s1 + n1h) : null,
     ensTemp1h:  slicePercentilesFrom(d.ensTemp1h,  s1, n1h), ensWind1h:  slicePercentilesFrom(d.ensWind1h,  s1, n1h),
     ensGust1h:  slicePercentilesFrom(d.ensGust1h,  s1, n1h), ensPrecip1h: slicePercentilesFrom(d.ensPrecip1h, s1, n1h),
   };
   const colW = portrait ? PORTRAIT_COL_W : null;
-  renderAll(s, invertedColors, colW);
-  lastRenderedData = s;
+  const displayData = portrait ? buildPortraitSeries(s) : s;
+  renderAll(displayData, invertedColors, colW);
+  lastRenderedData = displayData;
   if (invertedColors) {
     ['c-top', 'c-temp', 'c-dir', 'c-wind'].forEach(id => {
       const canvas = document.getElementById(id);
@@ -1061,7 +1147,7 @@ async function loadAtCoords(lat, lon, model) {
       });
     }
     const times=[],temps=[],precips=[],gusts=[],winds=[],dirs=[],codes=[];
-    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[],codes1h=[];
+    const times1h=[],temps1h=[],precips1h=[],gusts1h=[],winds1h=[],codes1h=[],dirs1h=[];
     const totalH = FORECAST_DAYS * 24;
     for (let i = 0; i < Math.min(totalH, H.time.length); i += STEP) {
       times.push(H.time[i]);
@@ -1089,6 +1175,7 @@ async function loadAtCoords(lat, lon, model) {
       const iconCode1h = iconCodes ? (iconCodes[i] ?? dmiCode1h) : dmiCode1h;
       codes1h.push((iconCodes && dmiCode1h >= 80 && dmiCode1h <= 82 && iconCode1h >= 95)
         ? iconCode1h : dmiCode1h);
+      dirs1h.push(H.winddirection_10m[i]);
     }
     const MODEL_LABEL = {
       'best_match':          'Auto',      'dmi_seamless':        'DMI HARMONIE',
@@ -1142,7 +1229,7 @@ async function loadAtCoords(lat, lon, model) {
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
-      times1h, temps1h, precips1h, gusts1h, winds1h, codes1h,
+      times1h, temps1h, precips1h, gusts1h, winds1h, codes1h, dirs1h,
       ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
     };
     requestAnimationFrame(() => requestAnimationFrame(() => renderDisplay(lastData)));

--- a/charts.js
+++ b/charts.js
@@ -166,7 +166,7 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
 /* ══════════════════════════════════════════════════
    DRAW TEMP + PRECIP
 ══════════════════════════════════════════════════ */
-function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h, ensPrecip3h, invertedColors = false, totalCssW = null) {
+function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h, ensPrecip3h, invertedColors = false, totalCssW = null, xMap = null) {
   const canvas = document.getElementById('c-temp');
   const wrap   = canvas.parentElement;
   const n      = times.length;
@@ -185,7 +185,7 @@ function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h,
   if (tmax-tmin < 15) { const mid=(tmin+tmax)/2; tmin=Math.floor((mid-7.5)/5)*5; tmax=tmin+15; }
   const tRange=tmax-tmin;
   const ty=t=>padT+(1-(t-tmin)/tRange)*ch;
-  const cx2=i=>(i+0.5)*colW;
+  const cx2 = xMap ? (i => xMap[i]) : (i => (i + 0.5) * colW);
 
   // 3hr precip geometry
   const pTimes = times3h || times;
@@ -210,7 +210,7 @@ function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h,
 
   // day dividers
   divs.forEach(i=>{
-    const x=i*colW;
+    const x = xMap ? (xMap[i - 1] + xMap[i]) / 2 : i * colW;
     ctx.strokeStyle='#667788'; ctx.lineWidth=1;
     ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,cssH); ctx.stroke();
   });
@@ -559,10 +559,7 @@ function _drawEnsGustExtendedBand(ctx, ensGust, ensWind, safeGusts, winds, n, cx
 
   // Build a horizontal gradient coloured by the p90 gust speed (top edge of the band).
   const grad = ctx.createLinearGradient(0, 0, cssW, 0);
-  allP90.forEach((g, i) => {
-    const stop = n > 1 ? i / (n - 1) : 0;
-    grad.addColorStop(stop, windColorStr(g, 0.2));
-  });
+  allP90.forEach((g, i) => grad.addColorStop(cx2(i) / cssW, windColorStr(g, 0.2)));
 
   ctx.beginPath();
   ctx.moveTo(cx2(0), wy(allP90[0]));
@@ -673,7 +670,7 @@ function _drawWindAxisLabels(wLevels, wy, WIND_H) {
 ══════════════════════════════════════════════════ */
 // times/gusts/winds are 1hr resolution; dirs is 3hr (same as drawWindDir);
 // times3h/winds3h are the 3hr arrays used only for kite highlights & pills.
-function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null) {
+function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null) {
   // --- canvas setup ---
   const canvas = document.getElementById('c-wind');
   const n      = times.length;
@@ -683,7 +680,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   const ctx    = resolveDPI(canvas, cssW, WIND_H);
   ctx.clearRect(0, 0, cssW, WIND_H);
   const divs = dayDivs(times);
-  const cx2  = i => (i + 0.5) * colW;
+  const cx2  = xMap ? (i => xMap[i]) : (i => (i + 0.5) * colW);
 
   // 3hr kite data (dirs align with times3h)
   const n3h    = (times3h || times).length;
@@ -722,7 +719,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   // --- grid & day dividers ---
   _drawWindGrid(ctx, wLevels, wy, cssW);
   divs.forEach(i => {
-    const x = i * colW;
+    const x = xMap ? (xMap[i - 1] + xMap[i]) / 2 : i * colW;
     ctx.strokeStyle = '#667788'; ctx.lineWidth = 1;
     ctx.beginPath(); ctx.moveTo(x, cY); ctx.lineTo(x, cY + WIND_H); ctx.stroke();
   });
@@ -737,7 +734,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   // --- wind fill (colour-mapped gradient below wind line) ---
   if (n > 1) {
     const grad = ctx.createLinearGradient(0, 0, cssW, 0);
-    winds.forEach((v, i) => grad.addColorStop(i / (n - 1), windColorStr(v, 0.72)));
+    winds.forEach((v, i) => grad.addColorStop(cx2(i) / cssW, windColorStr(v, 0.72)));
     ctx.fillStyle = grad;
     ctx.beginPath();
     ctx.moveTo(cx2(0), wy(winds[0]));
@@ -822,25 +819,20 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
    RENDER ALL
 ══════════════════════════════════════════════════ */
 function renderAll(d, invertedColors, portraitColW = null) {
-  // In portrait mode, anchor canvas width to the 1-hour slot count so the
-  // current day is displayed at the finest available time resolution (1h icons).
-  // Each draw function gets the same totalCssW guaranteeing perfect alignment:
-  //   1h data → colW = portraitColW (e.g. 24 px per hour)
-  //   3h data → colW = 3 × portraitColW (e.g. 72 px per 3-hour slot)
-  // In landscape mode use viewport width (null → each canvas measures its wrap).
+  // In portrait mode anchor the canvas width to the DISPLAY series slot count
+  // (N_display × portraitColW).  Curves use xMap1h to align their 1h data points
+  // onto this same grid.  In landscape mode each canvas measures its own wrap.
   const portrait = portraitColW != null;
-  const totalCssW = portrait ? d.times1h.length * portraitColW : null;
+  const totalCssW = portrait ? d.times.length * portraitColW : null;
 
-  // Top row: 1h data in portrait (one icon per hour), 3h data in landscape.
-  if (portrait && d.codes1h) {
-    drawTopRow(d.times1h, d.codes1h, d.precips1h, invertedColors, totalCssW);
-  } else {
-    drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
-  }
+  // Top row always uses the display series (variable-resolution in portrait,
+  // 3h in landscape) so each column is exactly one slot wide.
+  drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
   drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
-           d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW);
+           d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW,
+           d.xMap1h || null);
   drawWindDir(d.times, d.winds, d.dirs, totalCssW);
   drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
-           d.times, d.winds, invertedColors, totalCssW);
+           d.times, d.winds, invertedColors, totalCssW, d.xMap1h || null);
 }
 

--- a/charts.js
+++ b/charts.js
@@ -81,10 +81,16 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
     ctx.fillText(DA_DAYS[new Date(times[segs[s]]).getDay()], midX, TIME_H/2);
   }
 
-  // hour ticks 6,12,18
+  // Hour tick marks: every 3h for 1h-resolution data, every 6h for 3h-resolution data.
+  // With PORTRAIT_COL_W = 24 px per slot: 3h ticks are 72 px apart (1h data),
+  // or 6h ticks are 48 px apart (3h data) — both comfortable.
+  const stepHours = times.length >= 2
+    ? (new Date(times[1]).getTime() - new Date(times[0]).getTime()) / 3600000
+    : 3;
+  const tickEvery = stepHours <= 1 ? 3 : 6;
   times.forEach((t,i)=>{
     const h = new Date(t).getHours();
-    if(h===0||h%6!==0) return;
+    if(h===0||h%tickEvery!==0) return;
     const x = (i+0.5)*colW;
     ctx.fillStyle = textHr;
     ctx.font = `10px 'IBM Plex Mono', monospace`;
@@ -816,13 +822,21 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
    RENDER ALL
 ══════════════════════════════════════════════════ */
 function renderAll(d, invertedColors, portraitColW = null) {
-  // Compute a single total canvas width anchored to the 3-hour slot count.
-  // Every draw function receives this same value so all four canvases are
-  // *exactly* the same CSS width, guaranteeing perfect time-axis alignment
-  // when the user scrolls — regardless of whether a function uses 3 h or 1 h
-  // resolution data.
-  const totalCssW = portraitColW != null ? d.times.length * portraitColW : null;
-  drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
+  // In portrait mode, anchor canvas width to the 1-hour slot count so the
+  // current day is displayed at the finest available time resolution (1h icons).
+  // Each draw function gets the same totalCssW guaranteeing perfect alignment:
+  //   1h data → colW = portraitColW (e.g. 24 px per hour)
+  //   3h data → colW = 3 × portraitColW (e.g. 72 px per 3-hour slot)
+  // In landscape mode use viewport width (null → each canvas measures its wrap).
+  const portrait = portraitColW != null;
+  const totalCssW = portrait ? d.times1h.length * portraitColW : null;
+
+  // Top row: 1h data in portrait (one icon per hour), 3h data in landscape.
+  if (portrait && d.codes1h) {
+    drawTopRow(d.times1h, d.codes1h, d.precips1h, invertedColors, totalCssW);
+  } else {
+    drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
+  }
   drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
            d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW);
   drawWindDir(d.times, d.winds, d.dirs, totalCssW);

--- a/charts.js
+++ b/charts.js
@@ -127,9 +127,9 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
   });
 
   // icons — drawn on canvas
-  // Stride is a continuous float: MIN_ICON_PX / colW, clamped to [1, 2].
-  // stride=1 → every 3h slot; stride=2 → every 6h. Values in between give
-  // smooth, gradual thinning as the screen narrows.
+  // Stride is a continuous float: MIN_ICON_PX / colW, clamped to [1, 4].
+  // stride=1 → one icon per slot (1h in portrait, 3h in landscape); higher
+  // values skip slots smoothly as the viewport narrows.
   const MIN_ICON_PX = ICON_H * 0.65;
   const iconStride  = Math.min(4, Math.max(1, MIN_ICON_PX / colW));
   if (iconStride !== drawTopRow._lastStride) {

--- a/charts.js
+++ b/charts.js
@@ -820,19 +820,25 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
 ══════════════════════════════════════════════════ */
 function renderAll(d, invertedColors, portraitColW = null) {
   // In portrait mode anchor the canvas width to the DISPLAY series slot count
-  // (N_display × portraitColW).  Curves use xMap1h to align their 1h data points
-  // onto this same grid.  In landscape mode each canvas measures its own wrap.
+  // (N_display × portraitColW) and draw curves at that same resolution so the
+  // graph time zoom matches the icon row.  In landscape use full 1h curves.
   const portrait = portraitColW != null;
   const totalCssW = portrait ? d.times.length * portraitColW : null;
 
-  // Top row always uses the display series (variable-resolution in portrait,
-  // 3h in landscape) so each column is exactly one slot wide.
   drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
-  drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
-           d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW,
-           d.xMap1h || null);
   drawWindDir(d.times, d.winds, d.dirs, totalCssW);
-  drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
-           d.times, d.winds, invertedColors, totalCssW, d.xMap1h || null);
+  if (portrait) {
+    // Portrait: all charts share the display series — one column per slot.
+    drawTemp(d.times, d.temps, d.precips, d.ensTemp || null, d.ensPrecip || null,
+             null, null, null, invertedColors, totalCssW, null);
+    drawWind(d.times, d.gusts, d.winds, d.dirs, d.ensWind || null, d.ensGust || null,
+             null, null, invertedColors, totalCssW, null);
+  } else {
+    // Landscape: smooth 1h curves with display-series for precip bars / kite highlights.
+    drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
+             d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW, null);
+    drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
+             d.times, d.winds, invertedColors, totalCssW, null);
+  }
 }
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -512,6 +512,15 @@ describe('buildPortraitSeries', () => {
     expect(() => ctx.buildPortraitSeries(s)).not.toThrow();
   });
 
+  it('provides temps and gusts arrays at display-series resolution', () => {
+    const s = makeFixedSlice();
+    const ds = ctx.buildPortraitSeries(s);
+    expect(Array.isArray(ds.temps)).toBe(true);
+    expect(ds.temps).toHaveLength(ds.times.length);
+    expect(Array.isArray(ds.gusts)).toBe(true);
+    expect(ds.gusts).toHaveLength(ds.times.length);
+  });
+
   it('provides xMap1h and xFrac1h with length matching times1h', () => {
     const s = makeFixedSlice();
     const ds = ctx.buildPortraitSeries(s);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -278,7 +278,7 @@ function makeData(n3h, n1h, base = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000
     gusts: num3(), winds: num3(), dirs: num3(), codes: num3(),
     ensTemp: pct3(), ensWind: pct3(), ensGust: pct3(), ensPrecip: pct3(),
     times1h: arr1(), temps1h: num1(), precips1h: num1(),
-    gusts1h: num1(), winds1h: num1(),
+    gusts1h: num1(), winds1h: num1(), codes1h: num1(),
     ensTemp1h: pct1(), ensWind1h: pct1(), ensGust1h: pct1(), ensPrecip1h: pct1(),
   };
 }
@@ -316,6 +316,22 @@ describe('renderDisplay slicing', () => {
     ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
     expect(calls[0].ensTemp.p10).toHaveLength(calls[0].times.length);
     expect(calls[0].ensTemp1h.p50).toHaveLength(calls[0].times1h.length);
+  });
+
+  it('slices codes1h to match the 1h time window in portrait mode', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(calls[0].codes1h).not.toBeNull();
+    expect(calls[0].codes1h).toHaveLength(calls[0].times1h.length);
+  });
+
+  it('passes codes1h in landscape mode too (sliced to full 7-day window)', () => {
+    const calls = [];
+    const { ctx } = loadApp({ portrait: false, renderAllSpy: (d) => calls.push(d) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(calls[0].codes1h).not.toBeNull();
+    expect(calls[0].codes1h).toHaveLength(calls[0].times1h.length);
   });
 
   it('keeps full 7-day data in landscape mode (56×3h entries, 168×1h entries)', () => {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -278,7 +278,7 @@ function makeData(n3h, n1h, base = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000
     gusts: num3(), winds: num3(), dirs: num3(), codes: num3(),
     ensTemp: pct3(), ensWind: pct3(), ensGust: pct3(), ensPrecip: pct3(),
     times1h: arr1(), temps1h: num1(), precips1h: num1(),
-    gusts1h: num1(), winds1h: num1(), codes1h: num1(),
+    gusts1h: num1(), winds1h: num1(), codes1h: num1(), dirs1h: num1(),
     ensTemp1h: pct1(), ensWind1h: pct1(), ensGust1h: pct1(), ensPrecip1h: pct1(),
   };
 }
@@ -293,9 +293,11 @@ describe('renderDisplay slicing', () => {
     const d = makeData(TOTAL_3H, TOTAL_1H);
     ctx.renderDisplay(d);
     expect(calls).toHaveLength(1);
-    // Should extend to the very end of the input dataset (not capped at 36 h)
-    expect(calls[0].times.at(-1)).toBe(d.times.at(-1));
-    expect(calls[0].times1h.at(-1)).toBe(d.times1h.at(-1));
+    // Variable-resolution display series covers to near the end of the dataset
+    // (within one 6-hour step of the last 1h data point).
+    const lastDisplayMs = new Date(calls[0].times.at(-1)).getTime();
+    const lastDataMs    = new Date(d.times1h.at(-1)).getTime();
+    expect(lastDisplayMs).toBeGreaterThan(lastDataMs - 6 * 60 * 60 * 1000);
     // And should show more slots than the old 36-hour window (12 × 3h)
     expect(calls[0].times.length).toBeGreaterThan(12);
   });
@@ -382,6 +384,107 @@ describe('renderDisplay slicing', () => {
     const { ctx } = loadApp({ portrait: false, renderAllSpy: (d, ic, colW) => colWs.push(colW) });
     ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
     expect(colWs[0]).toBeNull();
+  });
+
+  it('includes dirs1h in sliced data passed to buildPortraitSeries', () => {
+    // In portrait the display series should use dirs1h-sourced directions.
+    // Verify by checking that renderAll receives a dirs array (not null/undefined).
+    const calls = [];
+    const { ctx } = loadApp({ portrait: true, renderAllSpy: (d) => calls.push(d) });
+    ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
+    expect(calls[0].dirs).toBeDefined();
+    expect(Array.isArray(calls[0].dirs)).toBe(true);
+    expect(calls[0].dirs.length).toBeGreaterThan(0);
+  });
+});
+
+// ── buildPortraitSeries ───────────────────────────────────────────────────────
+
+describe('buildPortraitSeries', () => {
+  const TOTAL_3H = (7 * 24) / 3;  // 56
+  const TOTAL_1H = 7 * 24;        // 168
+  const HR = 60 * 60 * 1000;
+
+  // Build the sliced `s` object that renderDisplay would pass to buildPortraitSeries.
+  // base = 24h ago so "now" is at times1h index 24 (first future slot).
+  function makeSlice() {
+    const base = new Date(Date.now() - 24 * HR);
+    const d = makeData(TOTAL_3H, TOTAL_1H, base);
+    // Give dirs1h distinct values so we can verify the right slot is picked.
+    d.dirs1h = Array.from({ length: TOTAL_1H }, (_, i) => i % 360);
+    const start = 24; // "now" index in 1h array
+    return {
+      times1h:   d.times1h.slice(start),
+      codes1h:   d.codes1h.slice(start),
+      dirs1h:    d.dirs1h.slice(start),
+      dirs:      d.dirs,
+      temps1h:   d.temps1h.slice(start),
+      precips1h: d.precips1h.slice(start),
+      gusts1h:   d.gusts1h.slice(start),
+      winds1h:   d.winds1h.slice(start),
+      ensTemp1h:   { p10: d.ensTemp1h.p10.slice(start), p50: d.ensTemp1h.p50.slice(start), p90: d.ensTemp1h.p90.slice(start) },
+      ensWind1h:   { p10: d.ensWind1h.p10.slice(start), p50: d.ensWind1h.p50.slice(start), p90: d.ensWind1h.p90.slice(start) },
+      ensGust1h:   { p10: d.ensGust1h.p10.slice(start), p50: d.ensGust1h.p50.slice(start), p90: d.ensGust1h.p90.slice(start) },
+      ensPrecip1h: { p10: d.ensPrecip1h.p10.slice(start), p50: d.ensPrecip1h.p50.slice(start), p90: d.ensPrecip1h.p90.slice(start) },
+    };
+  }
+
+  const { ctx } = loadApp({ portrait: true });
+
+  it('produces 1-hour spacing for the first 24 hours', () => {
+    const ds = ctx.buildPortraitSeries(makeSlice());
+    const dt = new Date(ds.times[1]).getTime() - new Date(ds.times[0]).getTime();
+    expect(dt).toBe(HR);
+  });
+
+  it('produces 3-hour spacing from 24–48h', () => {
+    const ds = ctx.buildPortraitSeries(makeSlice());
+    // Slot 24 is the first 3h-resolution slot (hoursAhead=24)
+    const dt = new Date(ds.times[25]).getTime() - new Date(ds.times[24]).getTime();
+    expect(dt).toBe(3 * HR);
+  });
+
+  it('produces 6-hour spacing from 48h onwards', () => {
+    const ds = ctx.buildPortraitSeries(makeSlice());
+    // First 24 slots = 1h zone, next 8 = 3h zone, index 32 = first 6h slot
+    const dt = new Date(ds.times[33]).getTime() - new Date(ds.times[32]).getTime();
+    expect(dt).toBe(6 * HR);
+  });
+
+  it('exposes both naming conventions (times/times1h, dirs/dirs1h, codes/codes1h)', () => {
+    const ds = ctx.buildPortraitSeries(makeSlice());
+    expect(ds.times).toBe(ds.times1h);
+    expect(ds.dirs).toBe(ds.dirs1h);
+    expect(ds.codes).toBe(ds.codes1h);
+    expect(ds.winds).toBe(ds.winds1h);
+    expect(ds.precips).toBe(ds.precips1h);
+  });
+
+  it('uses dirs1h for wind direction data', () => {
+    const ds = ctx.buildPortraitSeries(makeSlice());
+    // dirs1h values are i%360 (not all zero) so at least some should be non-zero
+    expect(ds.dirs.some(v => v !== 0)).toBe(true);
+  });
+
+  it('down-samples ensemble bands to match display series length', () => {
+    const ds = ctx.buildPortraitSeries(makeSlice());
+    expect(ds.ensTemp).not.toBeNull();
+    expect(ds.ensTemp.p10).toHaveLength(ds.times.length);
+    expect(ds.ensTemp1h).toBe(ds.ensTemp);
+  });
+
+  it('sets ensemble to null when input ensemble is null', () => {
+    const s = makeSlice();
+    s.ensTemp1h = null; s.ensWind1h = null; s.ensGust1h = null; s.ensPrecip1h = null;
+    const ds = ctx.buildPortraitSeries(s);
+    expect(ds.ensTemp).toBeNull();
+    expect(ds.ensTemp1h).toBeNull();
+  });
+
+  it('handles missing dirs1h by falling back to dirs', () => {
+    const s = makeSlice();
+    s.dirs1h = null;
+    expect(() => ctx.buildPortraitSeries(s)).not.toThrow();
   });
 });
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -401,80 +401,105 @@ describe('renderDisplay slicing', () => {
 // ── buildPortraitSeries ───────────────────────────────────────────────────────
 
 describe('buildPortraitSeries', () => {
-  const TOTAL_3H = (7 * 24) / 3;  // 56
-  const TOTAL_1H = 7 * 24;        // 168
+  const TOTAL_1H = 7 * 24;  // 168
   const HR = 60 * 60 * 1000;
 
-  // Build the sliced `s` object that renderDisplay would pass to buildPortraitSeries.
-  // base = 24h ago so "now" is at times1h index 24 (first future slot).
-  function makeSlice() {
-    const base = new Date(Date.now() - 24 * HR);
-    const d = makeData(TOTAL_3H, TOTAL_1H, base);
-    // Give dirs1h distinct values so we can verify the right slot is picked.
-    d.dirs1h = Array.from({ length: TOTAL_1H }, (_, i) => i % 360);
-    const start = 24; // "now" index in 1h array
+  // Fixed daytime UTC start so step computation is fully deterministic.
+  // 2025-06-16T10:00Z → h=10 (daytime), first slot is 1h.
+  // Night threshold: h < 6 || h >= 20 (fallback in VM context, no isNight function).
+  function makeFixedSlice() {
+    const base = new Date('2025-06-16T10:00:00.000Z');
+    const iso1 = (i) => new Date(base.getTime() + i * HR).toISOString();
+    const num1 = () => Array(TOTAL_1H).fill(0);
+    const pct1 = () => ({ p10: num1(), p50: num1(), p90: num1() });
+    // dirs1h has distinct values to verify daytime-preference slot selection.
+    const dirs = Array.from({ length: TOTAL_1H }, (_, i) => i % 360);
     return {
-      times1h:   d.times1h.slice(start),
-      codes1h:   d.codes1h.slice(start),
-      dirs1h:    d.dirs1h.slice(start),
-      dirs:      d.dirs,
-      temps1h:   d.temps1h.slice(start),
-      precips1h: d.precips1h.slice(start),
-      gusts1h:   d.gusts1h.slice(start),
-      winds1h:   d.winds1h.slice(start),
-      ensTemp1h:   { p10: d.ensTemp1h.p10.slice(start), p50: d.ensTemp1h.p50.slice(start), p90: d.ensTemp1h.p90.slice(start) },
-      ensWind1h:   { p10: d.ensWind1h.p10.slice(start), p50: d.ensWind1h.p50.slice(start), p90: d.ensWind1h.p90.slice(start) },
-      ensGust1h:   { p10: d.ensGust1h.p10.slice(start), p50: d.ensGust1h.p50.slice(start), p90: d.ensGust1h.p90.slice(start) },
-      ensPrecip1h: { p10: d.ensPrecip1h.p10.slice(start), p50: d.ensPrecip1h.p50.slice(start), p90: d.ensPrecip1h.p90.slice(start) },
+      times1h:     Array.from({ length: TOTAL_1H }, (_, i) => iso1(i)),
+      codes1h:     num1(),
+      dirs1h:      dirs,
+      dirs:        num1(),
+      temps1h:     num1(),
+      precips1h:   num1(),
+      gusts1h:     num1(),
+      winds1h:     num1(),
+      ensTemp1h:   pct1(),
+      ensWind1h:   pct1(),
+      ensGust1h:   pct1(),
+      ensPrecip1h: pct1(),
     };
   }
 
   const { ctx } = loadApp({ portrait: true });
 
-  it('produces 1-hour spacing for the first 24 hours', () => {
-    const ds = ctx.buildPortraitSeries(makeSlice());
+  // With base 2025-06-16T10:00Z the display series is:
+  //   idx 0..9  = 10:00..19:00 (1h steps, daytime in 0–24h zone)
+  //   idx 10    = 20:00 (night in 0–24h zone → step=3)
+  //   idx 11    = 23:00
+  //   idx 12    = 02:00 (day+1)
+  //   idx 13    = 05:00
+  //   idx 14    = 08:00 (back to daytime, hoursAhead=22, step=1)
+  //   idx 15    = 09:00
+  //   idx 16    = 10:00 (day+1, hoursAhead=24 → baseStep=3, step=3)
+  //   idx 17    = 13:00
+  //   idx 22    = 10:00 (day+2, hoursAhead=48 → baseStep=6, step=6)
+  //   idx 23    = 16:00
+
+  it('produces 1-hour spacing for daytime slots in the first 24 hours', () => {
+    const ds = ctx.buildPortraitSeries(makeFixedSlice());
     const dt = new Date(ds.times[1]).getTime() - new Date(ds.times[0]).getTime();
     expect(dt).toBe(HR);
   });
 
-  it('produces 3-hour spacing from 24–48h', () => {
-    const ds = ctx.buildPortraitSeries(makeSlice());
-    // Slot 24 is the first 3h-resolution slot (hoursAhead=24)
-    const dt = new Date(ds.times[25]).getTime() - new Date(ds.times[24]).getTime();
+  it('coarsens nighttime slots in the first 24 hours to 3h', () => {
+    const ds = ctx.buildPortraitSeries(makeFixedSlice());
+    // idx 10 = 20:00 (night), idx 11 = 23:00 → 3h gap
+    expect(new Date(ds.times[10]).getUTCHours()).toBe(20);
+    const dt = new Date(ds.times[11]).getTime() - new Date(ds.times[10]).getTime();
+    expect(dt).toBe(3 * HR);
+  });
+
+  it('produces 3-hour spacing for daytime slots in 24–48h', () => {
+    const ds = ctx.buildPortraitSeries(makeFixedSlice());
+    // idx 16 = day+1 10:00 (hoursAhead=24, daytime), idx 17 = 13:00 → 3h gap
+    const dt = new Date(ds.times[17]).getTime() - new Date(ds.times[16]).getTime();
     expect(dt).toBe(3 * HR);
   });
 
   it('produces 6-hour spacing from 48h onwards', () => {
-    const ds = ctx.buildPortraitSeries(makeSlice());
-    // First 24 slots = 1h zone, next 8 = 3h zone, index 32 = first 6h slot
-    const dt = new Date(ds.times[33]).getTime() - new Date(ds.times[32]).getTime();
+    const ds = ctx.buildPortraitSeries(makeFixedSlice());
+    // idx 22 = day+2 10:00 (hoursAhead=48), idx 23 = 16:00 → 6h gap
+    const dt = new Date(ds.times[23]).getTime() - new Date(ds.times[22]).getTime();
     expect(dt).toBe(6 * HR);
   });
 
-  it('exposes both naming conventions (times/times1h, dirs/dirs1h, codes/codes1h)', () => {
-    const ds = ctx.buildPortraitSeries(makeSlice());
-    expect(ds.times).toBe(ds.times1h);
-    expect(ds.dirs).toBe(ds.dirs1h);
-    expect(ds.codes).toBe(ds.codes1h);
-    expect(ds.winds).toBe(ds.winds1h);
-    expect(ds.precips).toBe(ds.precips1h);
+  it('times is the variable-resolution display series; times1h is the full 1h passthrough', () => {
+    const s = makeFixedSlice();
+    const ds = ctx.buildPortraitSeries(s);
+    expect(ds.times).not.toBe(ds.times1h);        // separate arrays
+    expect(ds.times1h).toBe(s.times1h);            // 1h passthrough
+    expect(ds.times.length).toBeLessThan(ds.times1h.length);
+    // Curve arrays are also passed through unmodified.
+    expect(ds.temps1h).toBe(s.temps1h);
+    expect(ds.winds1h).toBe(s.winds1h);
   });
 
-  it('uses dirs1h for wind direction data', () => {
-    const ds = ctx.buildPortraitSeries(makeSlice());
-    // dirs1h values are i%360 (not all zero) so at least some should be non-zero
+  it('uses dirs1h for the display-series wind direction data', () => {
+    const ds = ctx.buildPortraitSeries(makeFixedSlice());
+    // dirs1h values are i%360 (not all zero) so display dirs should be non-zero
     expect(ds.dirs.some(v => v !== 0)).toBe(true);
   });
 
-  it('down-samples ensemble bands to match display series length', () => {
-    const ds = ctx.buildPortraitSeries(makeSlice());
+  it('down-samples ensemble bands to match display series; passes through 1h ensemble', () => {
+    const s = makeFixedSlice();
+    const ds = ctx.buildPortraitSeries(s);
     expect(ds.ensTemp).not.toBeNull();
-    expect(ds.ensTemp.p10).toHaveLength(ds.times.length);
-    expect(ds.ensTemp1h).toBe(ds.ensTemp);
+    expect(ds.ensTemp.p10).toHaveLength(ds.times.length);  // down-sampled
+    expect(ds.ensTemp1h).toBe(s.ensTemp1h);                // 1h passthrough
   });
 
   it('sets ensemble to null when input ensemble is null', () => {
-    const s = makeSlice();
+    const s = makeFixedSlice();
     s.ensTemp1h = null; s.ensWind1h = null; s.ensGust1h = null; s.ensPrecip1h = null;
     const ds = ctx.buildPortraitSeries(s);
     expect(ds.ensTemp).toBeNull();
@@ -482,9 +507,45 @@ describe('buildPortraitSeries', () => {
   });
 
   it('handles missing dirs1h by falling back to dirs', () => {
-    const s = makeSlice();
+    const s = makeFixedSlice();
     s.dirs1h = null;
     expect(() => ctx.buildPortraitSeries(s)).not.toThrow();
+  });
+
+  it('provides xMap1h and xFrac1h with length matching times1h', () => {
+    const s = makeFixedSlice();
+    const ds = ctx.buildPortraitSeries(s);
+    expect(Array.isArray(ds.xMap1h)).toBe(true);
+    expect(ds.xMap1h.length).toBe(s.times1h.length);
+    expect(Array.isArray(ds.xFrac1h)).toBe(true);
+    expect(ds.xFrac1h.length).toBe(s.times1h.length);
+  });
+
+  it('xFrac1h values are strictly monotonically increasing and in (0, 1)', () => {
+    const s = makeFixedSlice();
+    const ds = ctx.buildPortraitSeries(s);
+    const xf = ds.xFrac1h;
+    for (let i = 1; i < xf.length; i++) {
+      expect(xf[i]).toBeGreaterThan(xf[i - 1]);
+    }
+    expect(xf[0]).toBeGreaterThan(0);
+    expect(xf[xf.length - 1]).toBeLessThan(1);
+  });
+
+  it('slotIdx1h maps each 1h point to a valid display slot index', () => {
+    const s = makeFixedSlice();
+    const ds = ctx.buildPortraitSeries(s);
+    expect(Array.isArray(ds.slotIdx1h)).toBe(true);
+    expect(ds.slotIdx1h.length).toBe(s.times1h.length);
+    const nDsp = ds.times.length;
+    for (const idx of ds.slotIdx1h) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(nDsp);
+    }
+    // Slot indices are non-decreasing
+    for (let i = 1; i < ds.slotIdx1h.length; i++) {
+      expect(ds.slotIdx1h[i]).toBeGreaterThanOrEqual(ds.slotIdx1h[i - 1]);
+    }
   });
 });
 


### PR DESCRIPTION
In portrait mode the top row now uses 1-hour data (codes1h + times1h) instead
of 3-hour data, so weather icons are drawn every hour rather than every 3 hours.
The canvas width is anchored to times1h.length × PORTRAIT_COL_W (24 px per
1-hour slot) giving icon stride ≈ 1 — one icon per hour with adequate space.

The 3-hour charts (wind direction arrows, precipitation bars) keep their data
but their colW = totalCssW / n3h = 3 × 24 px = 72 px per slot, preserving
perfect pixel-level time-axis alignment across all four canvas rows.

Time axis ticks adapt to data resolution: every 3 h for 1-hour data (72 px
apart), every 6 h for 3-hour data, so the axis is always legible.

- Build codes1h (1-hour weather codes with same DMI/ICON merge logic) in
  both load functions and store it alongside the other 1h arrays
- Slice codes1h into lastRenderedData so renderDisplay, tooltip, and
  crosshair system all have access to fine-grained codes
- Tooltip uses codes1h[idx1h] when available for more accurate icon/desc
- xh-top crosshair uses fracX1h when codes1h is present (portrait)

Tests: makeData extended with codes1h; two new slicing assertions added.

https://claude.ai/code/session_01RQhbbdV3Y8oXH7hchch6Lf