### PR TITLE
Replace GitHub Actions schedule with external cron and post-deploy trigger

### DIFF
--- a/.github/workflows/refresh-wind-data.yml
+++ b/.github/workflows/refresh-wind-data.yml
@@ -1,9 +1,7 @@
 name: Refresh wind station data
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'   # every 15 minutes (best-effort; GH scheduler may delay by hours)
-  workflow_dispatch:           # allow manual trigger
+  workflow_dispatch:           # triggered by cron-job.org every 15 min via GitHub API
   workflow_run:                # also run after every successful production deploy
     workflows: ["Build & Deploy (Production)"]
     types: [completed]

--- a/.github/workflows/refresh-wind-data.yml
+++ b/.github/workflows/refresh-wind-data.yml
@@ -2,8 +2,11 @@ name: Refresh wind station data
 
 on:
   schedule:
-    - cron: '*/15 * * * *'   # every 15 minutes
+    - cron: '*/15 * * * *'   # every 15 minutes (best-effort; GH scheduler may delay by hours)
   workflow_dispatch:           # allow manual trigger
+  workflow_run:                # also run after every successful production deploy
+    workflows: ["Build & Deploy (Production)"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -15,6 +18,8 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    # When triggered by workflow_run, only proceed if the deploy succeeded
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
This change replaces the built-in GitHub Actions schedule trigger with an external cron job service and adds a new trigger to run after successful production deployments. This approach provides more flexibility and ensures wind data is refreshed both on a regular interval and immediately after deployments.

## Key Changes
- Removed the native GitHub Actions `schedule` trigger (every 15 minutes)
- Added `workflow_dispatch` trigger with documentation that it's called by cron-job.org every 15 minutes via GitHub API
- Added `workflow_run` trigger to automatically run after successful "Build & Deploy (Production)" workflow completions
- Added conditional check to only proceed with `workflow_run` trigger if the production deployment succeeded

## Implementation Details
- The workflow now relies on an external cron service (cron-job.org) to periodically trigger the workflow via GitHub's API, providing more control over scheduling outside of GitHub Actions
- The `workflow_run` trigger includes a condition (`if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}`) to prevent the job from running if the triggering production deployment failed
- This ensures wind station data is kept fresh both through regular intervals and immediately after production updates

https://claude.ai/code/session_01Y1uYY1wLekkQ7PA1QqvcU8