### PR TITLE
Radar UI improvements: zoom, tooltip opacity, overlay toggles, tile zoom fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -528,8 +528,8 @@ function showTooltip(idx1h, idx3h) {
   const t   = new Date(timeStr);
   const day = DA_DAYS[t.getDay()];
   const h   = t.getHours().toString().padStart(2,'0');
-  const windCol = windColorStr(wind);
-  const gustCol = windColorStr(gust);
+  const windCol = windColorStr(wind, 1);
+  const gustCol = windColorStr(gust, 1);
   const fmt  = (v, deg) => (v >= 0 ? '+' : '') + v.toFixed(1) + (deg ? '°C' : ' m/s');
   const tempUncRow   = (tp10 != null && tp90 != null)
     ? `<div class="tt-row"><span class="tt-label">P10–P90</span><span class="tt-val" style="color:#bb8866;font-size:10px">${fmt(tp10,true)} → ${fmt(tp90,true)}</span></div>` : '';

--- a/radar.js
+++ b/radar.js
@@ -169,7 +169,7 @@
   // ── Create a tile layer, fire onReady() when all viewport tiles loaded
   function makeLayer(frame, opacity, onReady) {
     const l = new SafeTileLayer(frameUrl(frame), {
-      opacity, tileSize: 256, maxZoom: 12,
+      opacity, tileSize: 256, maxNativeZoom: 12,
       keepBuffer: 0, updateWhenIdle: true,
     });
     let pending = 0, errors = 0, probeUrl = null;
@@ -273,9 +273,9 @@
       // First-time init: load wind stations and start auto-refresh
       refreshWindStations();
       setInterval(refreshWindStations, 10 * 60 * 1000);
-      initWindToggle();
+      initOverlayToggles();
     }
-    radarMap.setView([lat, lon], 7);
+    radarMap.setView([lat, lon], 8);
   }
 
   // ── Loading overlay ───────────────────────────────────────────────────
@@ -442,12 +442,14 @@
     'https://api.allorigins.win/raw?url=' + encodeURIComponent(WIND_DIRECT),
     'https://corsproxy.io/?url='          + encodeURIComponent(WIND_DIRECT),
   ];
-  let windLayer       = null;
-  let windVisible     = true;
-  let ninjoActive     = false;  // true when ninjo-stations.json is in use
-  let dmiMarker       = null;   // DMI nearest-station arrow marker (lives inside windLayer)
-  let dmiAllMarkers   = [];     // All other DMI station dot-markers (lives inside windLayer)
-  let _lastWindGeo    = null;   // cache of last fetched wind-speeds.json (for dark-mode rebuild)
+  let trafikinfoLayer   = null;
+  let dmiLayer          = null;
+  let trafikinfoVisible = true;
+  let dmiVisible        = true;
+  let ninjoActive       = false;  // true when ninjo-stations.json is in use
+  let dmiMarker         = null;   // DMI nearest-station arrow marker (lives inside dmiLayer)
+  let dmiAllMarkers     = [];     // All other DMI station dot-markers (lives inside dmiLayer)
+  let _lastWindGeo      = null;   // cache of last fetched wind-speeds.json (for dark-mode rebuild)
 
   // True when the body has the 'inverted-colors' class set by app.js.
   const _inv = () => document.body.classList.contains('inverted-colors');
@@ -525,9 +527,9 @@
     return `rgb(${last[1]},${last[2]},${last[3]})`;
   }
 
-  /** Build markers from wind-speeds.json GeoJSON and add them to windLayer.
+  /** Build markers from wind-speeds.json GeoJSON and add them to the given layer.
    *  Colours are pre-inverted when in inverted-colours (dark) mode. */
-  function _addGeoMarkersToLayer(geo) {
+  function _addGeoMarkersToLayer(geo, layer) {
     const inv = _inv();
     (geo.features || []).forEach(f => {
       const [lon, lat] = f.geometry.coordinates;
@@ -557,17 +559,21 @@
       });
 
       L.marker([lat, lon], { icon, interactive: false })
-        .addTo(windLayer);
+        .addTo(layer);
     });
   }
 
   async function refreshWindStations() {
-    console.log('[map] refreshWindStations — radarMap:', !!radarMap, '| windVisible:', windVisible);
+    console.log('[map] refreshWindStations — radarMap:', !!radarMap,
+      '| trafikinfoVisible:', trafikinfoVisible, '| dmiVisible:', dmiVisible);
     if (!radarMap) { console.log('[map] skip — radarMap null'); return; }
 
     dmiMarker = null;
-    if (windLayer) { radarMap.removeLayer(windLayer); windLayer = null; }
-    windLayer = L.layerGroup();
+    dmiAllMarkers = [];
+    if (trafikinfoLayer) { radarMap.removeLayer(trafikinfoLayer); trafikinfoLayer = null; }
+    if (dmiLayer)        { radarMap.removeLayer(dmiLayer);        dmiLayer        = null; }
+    trafikinfoLayer = L.layerGroup();
+    dmiLayer        = L.layerGroup();
 
     try {
       // Fetch both sources in parallel ─────────────────────────────────────
@@ -581,7 +587,7 @@
       // ── Trafikkort (background, non-interactive) ─────────────────────────
       _lastWindGeo = geo;   // cache for dark-mode colour rebuild
       console.log(`[map · Trafikkort] ${geo ? (geo.features||[]).length : 0} features`);
-      if (geo) _addGeoMarkersToLayer(geo);
+      if (geo) _addGeoMarkersToLayer(geo, trafikinfoLayer);
 
       // ── NinJo stations ───────────────────────────────────────────────────
       // Stations in NINJO_HAS_HISTORY are confirmed DMI obs API stations:
@@ -611,7 +617,7 @@
               iconSize: [24, 38], iconAnchor: [12, 12],
             });
             L.marker([entry.latitude, entry.longitude], { icon, interactive: false })
-              .addTo(windLayer);
+              .addTo(dmiLayer);
             continue;
           }
 
@@ -661,7 +667,7 @@
               });
           });
 
-          marker.addTo(windLayer);
+          marker.addTo(dmiLayer);
         }
       }
     } catch (e) {
@@ -669,7 +675,8 @@
       ninjoActive = false;
     }
 
-    if (windVisible) windLayer.addTo(radarMap);
+    if (trafikinfoVisible) trafikinfoLayer.addTo(radarMap);
+    if (dmiVisible)        dmiLayer.addTo(radarMap);
     _refreshDmiMarker();
   }
 
@@ -947,7 +954,7 @@
 
   function _refreshDmiMarker() {
     console.log('[map · nearest] _refreshDmiMarker — radarMap:', !!radarMap,
-      '| windVisible:', windVisible,
+      '| dmiVisible:', dmiVisible,
       '| DMI_STATIONS:', window.DMI_STATIONS ? window.DMI_STATIONS.length + ' stations' : 'null');
 
     // NinJo already covers every station on the map — nothing to add.
@@ -958,11 +965,11 @@
 
     // ── Remove all stale DMI markers ──────────────────────────────────────
     if (dmiMarker) {
-      try { if (windLayer) windLayer.removeLayer(dmiMarker); } catch (_) {}
+      try { if (dmiLayer) dmiLayer.removeLayer(dmiMarker); } catch (_) {}
       dmiMarker = null;
     }
     for (const m of dmiAllMarkers) {
-      try { if (windLayer) windLayer.removeLayer(m); } catch (_) {}
+      try { if (dmiLayer) dmiLayer.removeLayer(m); } catch (_) {}
     }
     dmiAllMarkers = [];
 
@@ -973,9 +980,9 @@
       return;
     }
 
-    // windLayer may not exist yet if refreshWindStations() is still in-flight.
-    if (!windLayer) {
-      console.log('[map · nearest] windLayer not ready — retry in 500 ms');
+    // dmiLayer may not exist yet if refreshWindStations() is still in-flight.
+    if (!dmiLayer) {
+      console.log('[map · nearest] dmiLayer not ready — retry in 500 ms');
       setTimeout(_refreshDmiMarker, 500);
       return;
     }
@@ -1058,7 +1065,7 @@
           });
       });
 
-      marker.addTo(windLayer);
+      marker.addTo(dmiLayer);
       if (isNearest) {
         dmiMarker = marker;
         console.log(`[map · nearest] placed ${s.name} (${s.id}) —`,
@@ -1083,20 +1090,36 @@
   });
 
 
-  function initWindToggle() {
-    const btn = document.getElementById('radar-wind-toggle');
-    if (!btn) return;
-    btn.addEventListener('click', () => {
-      windVisible = !windVisible;
-      btn.classList.toggle('active', windVisible);
-      if (!radarMap) return;
-      if (windVisible) {
-        if (windLayer) { windLayer.addTo(radarMap); _refreshDmiMarker(); }
-        else refreshWindStations();
-      } else {
-        if (windLayer) radarMap.removeLayer(windLayer);
-      }
-    });
+  function initOverlayToggles() {
+    const trafikinfoBtn = document.getElementById('radar-trafikinfo-toggle');
+    if (trafikinfoBtn) {
+      trafikinfoBtn.addEventListener('click', () => {
+        trafikinfoVisible = !trafikinfoVisible;
+        trafikinfoBtn.classList.toggle('active', trafikinfoVisible);
+        if (!radarMap) return;
+        if (trafikinfoVisible) {
+          if (trafikinfoLayer) trafikinfoLayer.addTo(radarMap);
+          else refreshWindStations();
+        } else {
+          if (trafikinfoLayer) radarMap.removeLayer(trafikinfoLayer);
+        }
+      });
+    }
+
+    const dmiBtn = document.getElementById('radar-dmi-toggle');
+    if (dmiBtn) {
+      dmiBtn.addEventListener('click', () => {
+        dmiVisible = !dmiVisible;
+        dmiBtn.classList.toggle('active', dmiVisible);
+        if (!radarMap) return;
+        if (dmiVisible) {
+          if (dmiLayer) { dmiLayer.addTo(radarMap); _refreshDmiMarker(); }
+          else refreshWindStations();
+        } else {
+          if (dmiLayer) radarMap.removeLayer(dmiLayer);
+        }
+      });
+    }
   }
 })();
 

--- a/radar.js
+++ b/radar.js
@@ -170,7 +170,7 @@
   // ── Create a tile layer, fire onReady() when all viewport tiles loaded
   function makeLayer(frame, opacity, onReady) {
     const l = new SafeTileLayer(frameUrl(frame), {
-      opacity, tileSize: 256, maxNativeZoom: 12, maxZoom: 18,
+      opacity, tileSize: 256, maxNativeZoom: 7, maxZoom: 18,
       keepBuffer: 0, updateWhenIdle: true,
     });
     let pending = 0, errors = 0, probeUrl = null;

--- a/radar.js
+++ b/radar.js
@@ -170,7 +170,7 @@
   // ── Create a tile layer, fire onReady() when all viewport tiles loaded
   function makeLayer(frame, opacity, onReady) {
     const l = new SafeTileLayer(frameUrl(frame), {
-      opacity, tileSize: 256, maxNativeZoom: 12,
+      opacity, tileSize: 256, maxNativeZoom: 12, maxZoom: 18,
       keepBuffer: 0, updateWhenIdle: true,
     });
     let pending = 0, errors = 0, probeUrl = null;

--- a/radar.js
+++ b/radar.js
@@ -125,8 +125,13 @@
   //    request when we know the tile would 429 (or just to fill gaps).
   const TRANSPARENT_TILE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-  // ── Safe tile layer: guards _tileOnError against removed tiles, and
-  //    short-circuits createTile while rate-limited so no new 429s are fired.
+  // Maximum zoom level at which RainViewer has actual radar tiles.
+  // Requests above this are upscaled by Leaflet from the native-zoom tiles.
+  const RADAR_NATIVE_MAX_ZOOM = 7;
+
+  // ── Safe tile layer: guards _tileOnError against removed tiles,
+  //    short-circuits createTile while rate-limited, and hard-caps the
+  //    tile URL zoom so the RainViewer CDN never receives z > native max.
   const SafeTileLayer = L.TileLayer.extend({
     createTile(coords, done) {
       // While rate-limited, return a transparent placeholder immediately —
@@ -140,6 +145,14 @@
         return img;
       }
       return L.TileLayer.prototype.createTile.call(this, coords, done);
+    },
+    // Hard-cap the z value written into the tile URL regardless of what
+    // Leaflet's internal _tileZoom resolves to.
+    _getZoomForUrl() {
+      return Math.min(
+        L.TileLayer.prototype._getZoomForUrl.call(this),
+        RADAR_NATIVE_MAX_ZOOM
+      );
     },
     _tileOnError(done, tile, e) {
       if (!tile || !tile.el) return;
@@ -170,9 +183,10 @@
   // ── Create a tile layer, fire onReady() when all viewport tiles loaded
   function makeLayer(frame, opacity, onReady) {
     const l = new SafeTileLayer(frameUrl(frame), {
-      opacity, tileSize: 256, maxNativeZoom: 7, maxZoom: 18,
+      opacity, tileSize: 256, maxNativeZoom: RADAR_NATIVE_MAX_ZOOM, maxZoom: 18,
       keepBuffer: 0, updateWhenIdle: true,
     });
+    console.log(`[radar] makeLayer z≤${RADAR_NATIVE_MAX_ZOOM} — ${frameUrl(frame).replace('{z}/{x}/{y}','...')}`);
     let pending = 0, errors = 0, probeUrl = null;
     l.on('tileloadstart', (e) => {
       pending++;

--- a/radar.js
+++ b/radar.js
@@ -108,6 +108,7 @@
     dropStaging();
     clearTimeout(playTimeout);
     clearTimeout(rateLimitTimer);
+    hideLoadingOverlay();
     const el = document.getElementById('radar-tile-counter');
     if (el) { el.textContent = '429 – wait 60s'; el.className = 'limit'; }
     const genAtLimit = loadGen;

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -136,6 +136,41 @@ describe('_otherModelLineColor', () => {
   });
 });
 
+// ── windColorStr ─────────────────────────────────────────────────────────────
+
+describe('windColorStr', () => {
+  let ctx;
+  beforeEach(() => { ctx = loadChartLogic(); });
+
+  it('returns an rgba() string', () => {
+    expect(ctx.windColorStr(10)).toMatch(/^rgba\(\d+,\d+,\d+,[\d.]+\)$/);
+  });
+
+  it('without alphaOverride, calm wind (0 m/s) has alpha 0 (speed-based)', () => {
+    // WINDY_RAMP has alpha 0.00 at 0 m/s
+    expect(ctx.windColorStr(0)).toBe('rgba(130,190,255,0)');
+  });
+
+  it('alphaOverride=1 forces fully opaque even for calm wind', () => {
+    expect(ctx.windColorStr(0, 1)).toBe('rgba(130,190,255,1)');
+  });
+
+  it('alphaOverride=0 forces fully transparent regardless of speed', () => {
+    const result = ctx.windColorStr(10, 0);
+    expect(result).toMatch(/rgba\(\d+,\d+,\d+,0\)/);
+  });
+
+  it('alphaOverride=0.5 sets a custom alpha', () => {
+    const result = ctx.windColorStr(10, 0.5);
+    expect(result).toMatch(/rgba\(\d+,\d+,\d+,0\.5\)/);
+  });
+
+  it('high wind speed (10 m/s) has alpha 1 even without override', () => {
+    // WINDY_RAMP has alpha 1.00 at 10 m/s
+    expect(ctx.windColorStr(10)).toMatch(/rgba\(\d+,\d+,\d+,1\)/);
+  });
+});
+
 // ── isKiteDirOnly vs isKiteOptimal relationship ──────────────────────────────
 
 describe('isKiteDirOnly is a superset of isKiteOptimal', () => {

--- a/vejr.css
+++ b/vejr.css
@@ -151,7 +151,7 @@ canvas.main-canvas {
   z-index: 1000;
   bottom: max(10px, calc(env(safe-area-inset-bottom) + 4px));
   right:  max(10px, calc(env(safe-area-inset-right)  + 4px));
-  background: rgba(18, 26, 38, 0.93);
+  background: rgb(18, 26, 38);
   border: 1px solid rgba(120,160,200,0.35);
   border-radius: 6px;
   padding: 8px 11px;
@@ -583,8 +583,8 @@ canvas.main-canvas {
 .sdd-sea-cell  { color: #40c8a8; }
 .sdd-land-cell { color: #c88040; }
 
-/* ── Wind station toggle button ── */
-#radar-wind-toggle {
+/* ── Radar overlay toggle buttons ── */
+.radar-overlay-toggle {
   padding: 2px 8px;
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 10px;
@@ -596,8 +596,8 @@ canvas.main-canvas {
   transition: background 0.2s, color 0.2s, border-color 0.2s;
   font-weight: 400;
 }
-#radar-wind-toggle:hover { background: rgba(0,0,0,0.13); }
-#radar-wind-toggle.active {
+.radar-overlay-toggle:hover { background: rgba(0,0,0,0.13); }
+.radar-overlay-toggle.active {
   background: rgba(0,100,50,0.12);
   border-color: #5a8a6a;
   color: #1a6a3a;

--- a/vejr.html
+++ b/vejr.html
@@ -129,7 +129,8 @@
   <div id="radar-header">
     <span style="font-size:13px;font-weight:700;letter-spacing:0.2px;color:#111;">Radar – precipitation</span>
     <span id="radar-tile-counter" title="Tile requests today (max ~1000)">0 / 1000 tiles</span>
-    <button id="radar-wind-toggle" class="active" title="Toggle Danish wind station overlay">💨 Wind</button>
+    <button id="radar-trafikinfo-toggle" class="radar-overlay-toggle active" title="Toggle Trafikkort wind station overlay">Trafikinfo</button>
+    <button id="radar-dmi-toggle" class="radar-overlay-toggle active" title="Toggle DMI observation overlay">DMI obs</button>
     <span id="radar-source-label">RainViewer</span>
   </div>
   <div id="radar-map">


### PR DESCRIPTION
- Default map zoom increased from 7 to 8 (50% closer to POI)
- Hover tooltip background made fully opaque (was rgba 0.93)
- Replace single 'Wind' toggle with separate 'Trafikinfo' and 'DMI obs' toggles:
  Trafikkort (wind-speeds.json) and DMI/NinJo stations can now be shown/hidden independently
- Fix 'Zoom level not supported' tile errors when zooming in: replace maxZoom:12
  with maxNativeZoom:12 so Leaflet upscales tiles beyond zoom 12 instead of erroring

https://claude.ai/code/session_01D1KymaaogL2QSbvi2ir65E