### PR TITLE
Switch radar map to two-finger panning; one finger scrolls page

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -48,10 +48,44 @@
       radarMap.panBy([-dx, -dy], { animate: false });
     }
     function onEnd() { dragging = false; }
-    mapEl.addEventListener('touchstart',  e => { if (isMarkerTarget(e)) return; e.preventDefault(); onStart(e.touches[0].clientX, e.touches[0].clientY); }, { passive: false });
-    mapEl.addEventListener('touchmove',   e => { e.preventDefault(); onMove(e.touches[0].clientX,  e.touches[0].clientY); }, { passive: false });
+
+    // Show a brief "use two fingers to pan" hint when a single finger touches the map.
+    let hintTimeout = null;
+    const hintEl = document.createElement('div');
+    hintEl.id = 'radar-pan-hint';
+    hintEl.textContent = 'Use two fingers to pan';
+    mapEl.appendChild(hintEl);
+    function showHint() {
+      clearTimeout(hintTimeout);
+      hintEl.classList.add('visible');
+      hintTimeout = setTimeout(() => hintEl.classList.remove('visible'), 1200);
+    }
+
+    // Touch: one finger scrolls the page; two fingers pan the map.
+    mapEl.addEventListener('touchstart', e => {
+      if (isMarkerTarget(e)) return;
+      if (e.touches.length === 2) {
+        e.preventDefault();
+        const x = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        const y = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+        onStart(x, y);
+      } else if (e.touches.length === 1) {
+        showHint();
+      }
+    }, { passive: false });
+    mapEl.addEventListener('touchmove', e => {
+      if (dragging && e.touches.length === 2) {
+        e.preventDefault();
+        const x = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        const y = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+        onMove(x, y);
+      }
+      // Single finger: no preventDefault — let the page scroll naturally.
+    }, { passive: false });
     mapEl.addEventListener('touchend',    onEnd);
     mapEl.addEventListener('touchcancel', onEnd);
+
+    // Mouse: single click-drag still pans (desktop behaviour unchanged).
     mapEl.addEventListener('mousedown',   e => { if (isMarkerTarget(e)) return; e.preventDefault(); onStart(e.clientX, e.clientY); });
     window.addEventListener('mousemove',  e => onMove(e.clientX, e.clientY));
     window.addEventListener('mouseup',    onEnd);

--- a/vejr.css
+++ b/vejr.css
@@ -242,6 +242,25 @@ canvas.main-canvas {
 #radar-loading.hidden {
   opacity: 0;
 }
+#radar-pan-hint {
+  position: absolute;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.35);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s;
+}
+#radar-pan-hint.visible {
+  opacity: 1;
+}
 #radar-controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
On touch devices, a single finger now passes through to normal page
scroll. Two fingers pan the radar map (using the midpoint of both
touches). A brief "Use two fingers to pan" overlay appears on
single-finger contact to guide the user.

https://claude.ai/code/session_01UsbB11iuVLPnLVpJkLpNqX