### PR TITLE
Fix falsy-zero bug in kite config parsing and remove shore mask gating

### DIFF
--- a/app.js
+++ b/app.js
@@ -1189,9 +1189,11 @@ function renderShoreDebug() {
     if (seaThreshLabel)  seaThreshLabel.textContent = pct + '%';
   }
   function readDialogConfig() {
+    const parsedMin = parseFloat(minInput.value);
+    const parsedMax = parseFloat(maxInput.value);
     return {
-      min:       parseFloat(minInput.value) || KITE_DEFAULTS.min,
-      max:       parseFloat(maxInput.value) || KITE_DEFAULTS.max,
+      min:       isNaN(parsedMin) ? KITE_DEFAULTS.min : parsedMin,
+      max:       isNaN(parsedMax) ? KITE_DEFAULTS.max : parsedMax,
       dirs:      activeBearings.length ? activeBearings.slice() : KITE_DEFAULTS.dirs,
       daylight:  !daylightInput.checked,
       seaThresh: seaThreshSlider ? parseInt(seaThreshSlider.value) / 100 : KITE_DEFAULTS.seaThresh,

--- a/charts.js
+++ b/charts.js
@@ -409,15 +409,12 @@ function isKiteOptimal(speed, deg, timeStr) {
   if (KITE_CFG.daylight && isNight(timeStr)) return false;
   if (!isKiteDir(deg)) return false;
   if (speed < KITE_CFG.min || speed > KITE_CFG.max) return false;
-  // If shore analysis is available, require the wind to come from the sea
-  if (window.SHORE_MASK && !isSeaBearing(deg)) return false;
   return true;
 }
-/** Direction (and daylight/shore) match but speed may be outside the kite window. */
+/** Direction and daylight match but speed may be outside the kite window. */
 function isKiteDirOnly(deg, timeStr) {
   if (KITE_CFG.daylight && isNight(timeStr)) return false;
   if (!isKiteDir(deg)) return false;
-  if (window.SHORE_MASK && !isSeaBearing(deg)) return false;
   return true;
 }
 

--- a/config.js
+++ b/config.js
@@ -35,8 +35,8 @@ function parseKiteParams() {
                      || p.has('kite_at_night') || p.has('kite_sea_thresh');
 
   if (hasUrlParams) {
-    if (p.has('kite_min'))  cfg.min  = parseFloat(p.get('kite_min'))  || cfg.min;
-    if (p.has('kite_max'))  cfg.max  = parseFloat(p.get('kite_max'))  || cfg.max;
+    if (p.has('kite_min')) { const v = parseFloat(p.get('kite_min')); if (!isNaN(v)) cfg.min = v; }
+    if (p.has('kite_max')) { const v = parseFloat(p.get('kite_max')); if (!isNaN(v)) cfg.max = v; }
     if (p.has('kite_dirs')) cfg.dirs = p.get('kite_dirs').split(',').map(Number).filter(v => !isNaN(v)).map(snapBearing);
     if (p.has('kite_at_night')) cfg.daylight = p.get('kite_at_night') !== '0' ? false : true;
     if (p.has('kite_sea_thresh')) {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -171,6 +171,93 @@ describe('windColorStr', () => {
   });
 });
 
+// ── all-directions + night mode + range 0–10 (regression for falsy-zero bug) ─
+
+const ALL_DIRS = Array.from({ length: 36 }, (_, i) => i * 10);
+
+describe('isKiteOptimal – all directions, kite-at-night, range 0–10', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = loadChartLogic({
+      kiteCfg: { min: 0, max: 10, dirs: ALL_DIRS, daylight: false },
+    });
+  });
+
+  it('returns true for minimum edge speed (0 m/s) with any direction', () => {
+    expect(ctx.isKiteOptimal(0, 90,  '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(0, 0,   '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(0, 270, '2024-06-15T12:00')).toBe(true);
+  });
+
+  it('returns true for mid-range speed (5 m/s) with any direction', () => {
+    expect(ctx.isKiteOptimal(5, 0,   '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(5, 90,  '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(5, 180, '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(5, 270, '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(5, 350, '2024-06-15T12:00')).toBe(true);
+  });
+
+  it('returns true for maximum edge speed (10 m/s) with any direction', () => {
+    expect(ctx.isKiteOptimal(10, 90, '2024-06-15T12:00')).toBe(true);
+  });
+
+  it('returns false for speed just above maximum (11 m/s)', () => {
+    expect(ctx.isKiteOptimal(11, 90, '2024-06-15T12:00')).toBe(false);
+  });
+
+  it('returns true at night when kite-at-night is active (daylight=false)', () => {
+    expect(ctx.isKiteOptimal(5, 90, '2024-06-15T02:00')).toBe(true);
+    expect(ctx.isKiteOptimal(5, 90, '2024-06-15T23:00')).toBe(true);
+  });
+
+  it('highlights every compass bearing — no direction is excluded', () => {
+    for (let deg = 0; deg < 360; deg += 10) {
+      expect(ctx.isKiteOptimal(5, deg, '2024-06-15T12:00')).toBe(true);
+    }
+  });
+});
+
+describe('isKiteDirOnly – all directions, kite-at-night', () => {
+  let ctx;
+  beforeEach(() => {
+    ctx = loadChartLogic({
+      kiteCfg: { min: 0, max: 10, dirs: ALL_DIRS, daylight: false },
+    });
+  });
+
+  it('returns true for every 10° bearing in daylight', () => {
+    for (let deg = 0; deg < 360; deg += 10) {
+      expect(ctx.isKiteDirOnly(deg, '2024-06-15T12:00')).toBe(true);
+    }
+  });
+
+  it('returns true at night when daylight=false (night mode on)', () => {
+    expect(ctx.isKiteDirOnly(0,   '2024-06-15T02:00')).toBe(true);
+    expect(ctx.isKiteDirOnly(90,  '2024-06-15T02:00')).toBe(true);
+    expect(ctx.isKiteDirOnly(270, '2024-06-15T23:00')).toBe(true);
+  });
+
+  it('returns false at night when daylight=true (night mode off)', () => {
+    const dayCtx = loadChartLogic({
+      kiteCfg: { min: 0, max: 10, dirs: ALL_DIRS, daylight: true },
+    });
+    expect(dayCtx.isKiteDirOnly(90,  '2024-06-15T02:00')).toBe(false);
+    expect(dayCtx.isKiteDirOnly(270, '2024-06-15T23:00')).toBe(false);
+  });
+
+  it('direction row is highlighted for all bearings whenever isKiteOptimal is true', () => {
+    const cases = [0, 5, 10].flatMap(speed =>
+      ALL_DIRS.map(deg => [speed, deg])
+    );
+    for (const [speed, deg] of cases) {
+      const t = '2024-06-15T12:00';
+      if (ctx.isKiteOptimal(speed, deg, t)) {
+        expect(ctx.isKiteDirOnly(deg, t)).toBe(true);
+      }
+    }
+  });
+});
+
 // ── isKiteDirOnly vs isKiteOptimal relationship ──────────────────────────────
 
 describe('isKiteDirOnly is a superset of isKiteOptimal', () => {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -171,6 +171,57 @@ describe('windColorStr', () => {
   });
 });
 
+// ── SHORE_MASK must not override KITE_CFG.dirs ──────────────────────────────
+
+describe('isKiteOptimal – SHORE_MASK does not gate bearings already in dirs', () => {
+  it('returns true for a "land" bearing when it is explicitly in KITE_CFG.dirs', () => {
+    // SHORE_MASK marks bearing 0 as 0% sea (pure land), but user has 0 in dirs.
+    const mask = new Float32Array(36); // all zeros → 0% sea for every bearing
+    const ctx = loadChartLogic({
+      kiteCfg: { min: 0, max: 15, dirs: [0, 90, 180, 270], daylight: false },
+      shoreMask: mask,
+    });
+    expect(ctx.isKiteOptimal(8, 0,   '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(8, 90,  '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(8, 180, '2024-06-15T12:00')).toBe(true);
+    expect(ctx.isKiteOptimal(8, 270, '2024-06-15T12:00')).toBe(true);
+  });
+
+  it('returns true for all 36 bearings with SHORE_MASK fully populated as land', () => {
+    const mask = new Float32Array(36); // all 0% sea
+    const ctx = loadChartLogic({
+      kiteCfg: { min: 0, max: 15, dirs: ALL_DIRS, daylight: false },
+      shoreMask: mask,
+    });
+    for (let deg = 0; deg < 360; deg += 10) {
+      expect(ctx.isKiteOptimal(5, deg, '2024-06-15T12:00')).toBe(true);
+    }
+  });
+
+  it('still returns false for a bearing not in KITE_CFG.dirs regardless of SHORE_MASK', () => {
+    const mask = new Float32Array(36).fill(1); // all 100% sea
+    const ctx = loadChartLogic({
+      kiteCfg: { min: 0, max: 15, dirs: [90, 270], daylight: false },
+      shoreMask: mask,
+    });
+    expect(ctx.isKiteOptimal(8, 0,   '2024-06-15T12:00')).toBe(false);
+    expect(ctx.isKiteOptimal(8, 180, '2024-06-15T12:00')).toBe(false);
+  });
+});
+
+describe('isKiteDirOnly – SHORE_MASK does not gate bearings already in dirs', () => {
+  it('returns true for "land" bearings that are in KITE_CFG.dirs', () => {
+    const mask = new Float32Array(36); // all 0% sea
+    const ctx = loadChartLogic({
+      kiteCfg: { min: 0, max: 15, dirs: ALL_DIRS, daylight: false },
+      shoreMask: mask,
+    });
+    for (let deg = 0; deg < 360; deg += 10) {
+      expect(ctx.isKiteDirOnly(deg, '2024-06-15T12:00')).toBe(true);
+    }
+  });
+});
+
 // ── all-directions + night mode + range 0–10 (regression for falsy-zero bug) ─
 
 const ALL_DIRS = Array.from({ length: 36 }, (_, i) => i * 10);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -109,4 +109,40 @@ describe('kite settings – localStorage persistence (iOS Home Screen fix)', () 
     expect(cfg.dirs).toEqual([90, 270]);
     expect(cfg.daylight).toBe(true);
   });
+
+  it('parseKiteParams accepts kite_min=0 without falling back to default', () => {
+    // Regression: parseFloat('0') is falsy — must use isNaN guard, not || fallback
+    const ctx = loadScripts('config.js');
+    ctx.window.location.search = '?kite_min=0&kite_max=10';
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.min).toBe(0);
+    expect(cfg.max).toBe(10);
+  });
+
+  it('parseKiteParams accepts kite_max=0 without falling back to default', () => {
+    const ctx = loadScripts('config.js');
+    ctx.window.location.search = '?kite_max=0';
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.max).toBe(0);
+  });
+
+  it('parseKiteParams with kite_min=0 in localStorage restores zero correctly', () => {
+    const ctx = loadScripts('config.js');
+    ctx.localStorage.setItem('vejr_kite_cfg', JSON.stringify({ min: 0, max: 10, dirs: [90], daylight: false }));
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.min).toBe(0);
+    expect(cfg.max).toBe(10);
+  });
+
+  it('parseKiteParams with all 36 bearings in kite_dirs preserves every bearing', () => {
+    const allDirs = Array.from({ length: 36 }, (_, i) => i * 10);
+    const ctx = loadScripts('config.js');
+    ctx.window.location.search = '?kite_dirs=' + allDirs.join(',') + '&kite_at_night=1';
+    const cfg = ctx.parseKiteParams();
+    expect(cfg.dirs).toHaveLength(36);
+    expect(cfg.dirs).toContain(0);
+    expect(cfg.dirs).toContain(180);
+    expect(cfg.dirs).toContain(350);
+    expect(cfg.daylight).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where kite configuration parameters with a value of `0` were incorrectly treated as falsy and replaced with defaults. It also removes the shore mask gating logic that was preventing valid wind directions from being highlighted.

## Key Changes

- **Fixed falsy-zero bug in config parsing**: Replaced `||` fallback operators with explicit `isNaN()` checks in `config.js` and `app.js` to properly handle `0` as a valid configuration value for `kite_min` and `kite_max`
  - `parseKiteParams()` now correctly accepts `kite_min=0` and `kite_max=0` from URL parameters
  - `readDialogConfig()` in the UI dialog now properly preserves zero values

- **Removed shore mask gating from direction validation**: Deleted the `SHORE_MASK` checks from `isKiteOptimal()` and `isKiteDirOnly()` functions in `charts.js`
  - Shore mask no longer prevents bearings that are explicitly in `KITE_CFG.dirs` from being highlighted
  - Simplified the logic: direction validation now depends only on the configured directions, not on coastal geography

- **Added comprehensive test coverage**: New test suites verify:
  - Zero values are correctly parsed from URL parameters and localStorage
  - All 36 compass bearings can be configured and work correctly
  - Shore mask does not override user-configured directions
  - Night mode (kite-at-night) works with all-directions configuration
  - The relationship between `isKiteOptimal()` and `isKiteDirOnly()` is maintained

## Implementation Details

The core issue was using the `||` operator for fallback logic, which treats `0` as falsy. The fix uses `isNaN()` to distinguish between invalid input (NaN) and valid zero values. This pattern is now consistently applied across configuration parsing in both URL parameters and localStorage restoration.

https://claude.ai/code/session_01E6MBcjR4bT93cCYgaAhzXE