### PR TITLE
Fix radar map height to keep footer below fold on initial load

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -449,8 +449,9 @@
   }
 
   // ── Radar height fitting ──────────────────────────────────────────────
-  // Expand #radar-map so that the footer sits just below the visible area
-  // when the user has scrolled the radar section to the top of the viewport.
+  // Size #radar-map so the footer sits just below the fold when the page
+  // is at scroll position 0 — i.e. the radar section fills whatever
+  // vertical space remains below the forecast charts.
   function _fitRadarHeight() {
     const section    = document.getElementById('radar-section');
     const mapEl      = document.getElementById('radar-map');
@@ -459,9 +460,13 @@
     if (!section || section.style.display === 'none') return;
     const headerH   = headerEl   ? headerEl.offsetHeight   : 34;
     const controlsH = controlsEl ? controlsEl.offsetHeight : 34;
-    // 12px = section margin-top; 2px = top + bottom section border
-    const overhead  = 12 + 2 + headerH + controlsH;
-    mapEl.style.minHeight = Math.max(320, window.innerHeight - overhead) + 'px';
+    // section.offsetTop = distance from document top to section border-box.
+    // footer has margin-top: 12px.  We want footer-top = window.innerHeight
+    // (just below fold) when scrollY = 0, so:
+    //   section.offsetTop + sectionHeight + 12 = window.innerHeight
+    //   mapHeight = window.innerHeight - section.offsetTop - 12 - headerH - controlsH - 2 (borders)
+    const mapH = window.innerHeight - section.offsetTop - 12 - headerH - controlsH - 2;
+    mapEl.style.minHeight = Math.max(320, mapH) + 'px';
   }
 
   // ── Resize / orientation ──────────────────────────────────────────────

--- a/radar.js
+++ b/radar.js
@@ -419,6 +419,7 @@
 
       _seenTiles.clear();
       document.getElementById('radar-section').style.display = 'flex';
+      _fitRadarHeight();
 
       // initMap must run after the section is visible so Leaflet can
       // measure the container dimensions correctly on first init.
@@ -447,10 +448,27 @@
     }
   }
 
+  // ── Radar height fitting ──────────────────────────────────────────────
+  // Expand #radar-map so that the footer sits just below the visible area
+  // when the user has scrolled the radar section to the top of the viewport.
+  function _fitRadarHeight() {
+    const section    = document.getElementById('radar-section');
+    const mapEl      = document.getElementById('radar-map');
+    const headerEl   = document.getElementById('radar-header');
+    const controlsEl = document.getElementById('radar-controls');
+    if (!section || section.style.display === 'none') return;
+    const headerH   = headerEl   ? headerEl.offsetHeight   : 34;
+    const controlsH = controlsEl ? controlsEl.offsetHeight : 34;
+    // 12px = section margin-top; 2px = top + bottom section border
+    const overhead  = 12 + 2 + headerH + controlsH;
+    mapEl.style.minHeight = Math.max(320, window.innerHeight - overhead) + 'px';
+  }
+
   // ── Resize / orientation ──────────────────────────────────────────────
   function onOrientationChange() {
+    _fitRadarHeight();
     if (!radarMap) return;
-    setTimeout(() => radarMap.invalidateSize(), 300);
+    setTimeout(() => { _fitRadarHeight(); radarMap.invalidateSize(); }, 300);
   }
   window.addEventListener('resize', onOrientationChange);
   screen.orientation?.addEventListener('change', onOrientationChange);

--- a/vejr.css
+++ b/vejr.css
@@ -834,13 +834,6 @@ body.inverted-colors #app-footer { filter: invert(1); }
   }
 }
 
-/* ── Landscape (mobile): expand radar section to fill viewport so the footer
-      is just below the fold and reachable by scrolling ── */
-@media (orientation: landscape) and (max-height: 600px) {
-  #radar-section {
-    min-height: calc(100dvh - 12px); /* 12px = section's own margin-top */
-  }
-}
 
 /* ── Inverted colours (iOS): applied via JS body class (matchMedia works;
       @media (inverted-colors) does not reliably fire in WKWebView) ── */

--- a/vejr.css
+++ b/vejr.css
@@ -834,6 +834,14 @@ body.inverted-colors #app-footer { filter: invert(1); }
   }
 }
 
+/* ── Landscape (mobile): expand radar section to fill viewport so the footer
+      is just below the fold and reachable by scrolling ── */
+@media (orientation: landscape) and (max-height: 600px) {
+  #radar-section {
+    min-height: calc(100dvh - 12px); /* 12px = section's own margin-top */
+  }
+}
+
 /* ── Inverted colours (iOS): applied via JS body class (matchMedia works;
       @media (inverted-colors) does not reliably fire in WKWebView) ── */
 


### PR DESCRIPTION
## Summary
This PR adds automatic height fitting for the radar map section to ensure the footer sits just below the viewport fold when the page is at scroll position 0, improving the initial layout experience.

## Key Changes
- **New `_fitRadarHeight()` function**: Calculates and applies the optimal height for the radar map based on:
  - Available viewport height
  - Position of the radar section from document top
  - Heights of radar header and controls elements
  - Footer margin spacing
  - Sets a minimum height of 320px to maintain usability on small screens

- **Call `_fitRadarHeight()` on radar section display**: Invoked when the radar section becomes visible to ensure proper sizing from the start

- **Call `_fitRadarHeight()` on resize/orientation changes**: Integrated into the `onOrientationChange()` handler to recalculate heights when viewport dimensions change, both immediately and after the Leaflet map invalidation delay

## Implementation Details
The function calculates the map height using the formula:
```
mapHeight = window.innerHeight - section.offsetTop - 12px (footer margin) - headerHeight - controlsHeight - 2px (borders)
```

This ensures that when scrollY = 0, the footer's top edge aligns with the bottom of the viewport, creating a seamless layout without unnecessary scrolling on initial page load.

https://claude.ai/code/session_01G8wjaKtJgtBZKCRwJggR91