### PR TITLE
Include branch name in build version string

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Inject build number
         run: |
-          BUILD=$(date -u '+%Y.%m.%d')-${{ github.run_number }}
+          BRANCH=$(echo "${{ github.ref_name }}" | tr '/' '-')
+          BUILD=$(date -u '+%Y.%m.%d')-${{ github.run_number }}-$BRANCH
           sed -i "s/%%BUILD_NUMBER%%/$BUILD/g" vejr.html
           sed -i "s/%%BUILD_NUMBER%%/$BUILD/g" sw.js
 


### PR DESCRIPTION
## Summary
Updated the build number generation in the deployment workflow to include the git branch name, making it easier to identify which branch a build originated from.

## Changes
- Modified the build number format to include the branch name as a suffix
- The branch name is sanitized by replacing forward slashes with hyphens to ensure compatibility with the build string format
- Build number now follows the pattern: `YYYY.MM.DD-{run_number}-{branch_name}`

## Implementation Details
- Branch name is extracted from `github.ref_name` and normalized using `tr '/' '-'` to handle branch names with path separators (e.g., `feature/my-feature` becomes `feature-my-feature`)
- The updated build string is injected into both `vejr.html` and `sw.js` files as before

https://claude.ai/code/session_013EEvAEQiWKPonvd6VVWNS4