### PR TITLE
Add context menu and Ctrl+scroll zoom to radar map

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -2,6 +2,23 @@
    RAINVIEWER RADAR
 ══════════════════════════════════════════════════ */
 
+/**
+ * Clamp a context-menu position so it stays inside the viewport.
+ * Returns the adjusted { x, y } using fixed coordinates (for position:fixed menus).
+ * @param {number} cx - mouse clientX
+ * @param {number} cy - mouse clientY
+ * @param {number} vw - viewport width  (window.innerWidth)
+ * @param {number} vh - viewport height (window.innerHeight)
+ * @param {number} [estW=180] - estimated menu width
+ * @param {number} [estH=40]  - estimated menu height
+ */
+function _clampMenuPos(cx, cy, vw, vh, estW = 180, estH = 40) {
+  return {
+    x: cx + estW > vw ? cx - estW : cx,
+    y: cy + estH > vh ? cy - estH : cy,
+  };
+}
+
 /** Extract the most local place name from a Nominatim reverse-geocode response. */
 function _parseNominatimPlace(d) {
   if (!d) return null;
@@ -51,6 +68,57 @@ window.OBS_HISTORY_URL = OBS_HISTORY_URL;
   const timeLabel = document.getElementById('radar-time-label');
   const zoomIn    = document.getElementById('radar-zoom-in');
   const zoomOut   = document.getElementById('radar-zoom-out');
+
+  // ── Desktop right-click context menu ─────────────────────────────────
+  function attachContextMenu(mapEl) {
+    let ctxMenuEl = null;
+    let pendingLatLng = null;
+
+    function buildMenu() {
+      const div = document.createElement('div');
+      div.id = 'radar-ctx-menu';
+      const item = document.createElement('div');
+      item.className = 'radar-ctx-item';
+      item.textContent = 'Set position here';
+      item.addEventListener('click', () => {
+        div.classList.remove('visible');
+        if (pendingLatLng && onMarkerDragEnd) {
+          const { lat, lng } = pendingLatLng;
+          placeLocationMarkers(lat, lng);
+          onMarkerDragEnd(lat, lng);
+        }
+      });
+      div.appendChild(item);
+      document.body.appendChild(div);
+      return div;
+    }
+
+    mapEl.addEventListener('contextmenu', e => {
+      if (!window.matchMedia('(hover: hover) and (pointer: fine)').matches) return;
+      e.preventDefault();
+      if (!radarMap) return;
+
+      if (!ctxMenuEl) ctxMenuEl = buildMenu();
+
+      const rect = mapEl.getBoundingClientRect();
+      pendingLatLng = radarMap.containerPointToLatLng(
+        [e.clientX - rect.left, e.clientY - rect.top]
+      );
+
+      // Position the menu, flipping toward the inside edge when near viewport boundary
+      const { x, y } = _clampMenuPos(e.clientX, e.clientY, window.innerWidth, window.innerHeight);
+      ctxMenuEl.style.left = x + 'px';
+      ctxMenuEl.style.top  = y + 'px';
+      ctxMenuEl.classList.add('visible');
+    });
+
+    document.addEventListener('click', e => {
+      if (ctxMenuEl && !ctxMenuEl.contains(e.target)) ctxMenuEl.classList.remove('visible');
+    });
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape' && ctxMenuEl) ctxMenuEl.classList.remove('visible');
+    });
+  }
 
   // ── Map drag ──────────────────────────────────────────────────────────
   function attachMapDrag(mapEl) {
@@ -112,6 +180,32 @@ window.OBS_HISTORY_URL = OBS_HISTORY_URL;
     mapEl.addEventListener('mousedown',   e => { if (isMarkerTarget(e)) return; e.preventDefault(); onStart(e.clientX, e.clientY); });
     window.addEventListener('mousemove',  e => onMove(e.clientX, e.clientY));
     window.addEventListener('mouseup',    onEnd);
+
+    // Desktop: Ctrl+scroll zooms the map; plain scroll scrolls the page and
+    // shows a transient hint pointing to Ctrl+scroll.
+    const scrollHintEl = document.createElement('div');
+    scrollHintEl.id = 'radar-scroll-hint';
+    scrollHintEl.textContent = 'Use Ctrl + scroll to zoom';
+    mapEl.appendChild(scrollHintEl);
+
+    let scrollHintTimeout = null;
+    function showScrollHint() {
+      clearTimeout(scrollHintTimeout);
+      scrollHintEl.classList.add('visible');
+      scrollHintTimeout = setTimeout(() => scrollHintEl.classList.remove('visible'), 1500);
+    }
+
+    mapEl.addEventListener('wheel', e => {
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (radarMap) radarMap.setZoom(radarMap.getZoom() + (e.deltaY < 0 ? 1 : -1));
+      } else {
+        // Only show hint on pointer devices (not trackpad-only touch-sim)
+        if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) showScrollHint();
+        // No preventDefault — let the page scroll naturally
+      }
+    }, { passive: false });
   }
 
   // ── Daily tile-request counter (persisted in localStorage) ───────────
@@ -320,6 +414,7 @@ window.OBS_HISTORY_URL = OBS_HISTORY_URL;
       radarMap = L.map('radar-map', {
         zoomControl: false, attributionControl: false,
         dragging: false, inertia: false,
+        scrollWheelZoom: false,
       });
       L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
         maxZoom: 19,
@@ -327,6 +422,7 @@ window.OBS_HISTORY_URL = OBS_HISTORY_URL;
       zoomIn.addEventListener('click',  () => radarMap.zoomIn());
       zoomOut.addEventListener('click', () => radarMap.zoomOut());
       attachMapDrag(document.getElementById('radar-map'));
+      attachContextMenu(document.getElementById('radar-map'));
 
       let moveDebounce = null;
       radarMap.on('movestart', () => {

--- a/tests/radar.test.js
+++ b/tests/radar.test.js
@@ -4,7 +4,7 @@ import { loadScripts } from './helpers/loader.js';
 // radar.js is an IIFE that requires Leaflet (L). Without it the IIFE returns
 // early, but module-level helpers defined before the IIFE are still available.
 const ctx = loadScripts('radar.js');
-const { _parseNominatimPlace, _nominatimHasLocalDetail } = ctx;
+const { _parseNominatimPlace, _nominatimHasLocalDetail, _clampMenuPos } = ctx;
 
 describe('OBS_HISTORY_URL', () => {
   it('points to raw.githubusercontent.com data branch', () => {
@@ -105,6 +105,47 @@ describe('_nominatimHasLocalDetail', () => {
 
   it('returns true when hamlet is present', () => {
     expect(_nominatimHasLocalDetail({ address: { hamlet: 'Lille Skensved' } })).toBe(true);
+  });
+});
+
+describe('_clampMenuPos', () => {
+  it('returns the click point when there is room to the right and below', () => {
+    const { x, y } = _clampMenuPos(100, 100, 1280, 800);
+    expect(x).toBe(100);
+    expect(y).toBe(100);
+  });
+
+  it('flips left when menu would overflow the right viewport edge', () => {
+    // clientX=1200, estW=180 → 1200+180=1380 > 1280, so flip: x = 1200-180 = 1020
+    const { x } = _clampMenuPos(1200, 100, 1280, 800);
+    expect(x).toBe(1020);
+  });
+
+  it('flips up when menu would overflow the bottom viewport edge', () => {
+    // clientY=780, estH=40 → 780+40=820 > 800, so flip: y = 780-40 = 740
+    const { y } = _clampMenuPos(100, 780, 1280, 800);
+    expect(y).toBe(740);
+  });
+
+  it('flips both axes when near the bottom-right corner', () => {
+    const { x, y } = _clampMenuPos(1200, 780, 1280, 800);
+    expect(x).toBe(1020);
+    expect(y).toBe(740);
+  });
+
+  it('respects custom estimated dimensions', () => {
+    // estW=200, estH=60
+    const { x, y } = _clampMenuPos(1100, 760, 1280, 800, 200, 60);
+    // 1100+200=1300 > 1280 → flip x: 1100-200=900
+    expect(x).toBe(900);
+    // 760+60=820 > 800 → flip y: 760-60=700
+    expect(y).toBe(700);
+  });
+
+  it('does not flip when click is exactly at the edge with room for default menu size', () => {
+    // clientX=1100, estW=180 → 1100+180=1280 = vw (not strictly greater) → no flip
+    const { x } = _clampMenuPos(1100, 100, 1280, 800);
+    expect(x).toBe(1100);
   });
 });
 

--- a/vejr.css
+++ b/vejr.css
@@ -261,6 +261,51 @@ canvas.main-canvas {
 #radar-pan-hint.visible {
   opacity: 1;
 }
+#radar-scroll-hint {
+  position: absolute;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.35);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s;
+}
+#radar-scroll-hint.visible {
+  opacity: 1;
+}
+#radar-ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  background: #fff;
+  border: 1px solid #c0c8d0;
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.18);
+  padding: 4px 0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 13px;
+  min-width: 160px;
+  display: none;
+}
+#radar-ctx-menu.visible {
+  display: block;
+}
+.radar-ctx-item {
+  padding: 8px 16px;
+  cursor: pointer;
+  color: #222;
+  white-space: nowrap;
+  user-select: none;
+}
+.radar-ctx-item:hover {
+  background: #eef2f8;
+}
 #radar-controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Enhances the radar map with two new desktop interaction features: a right-click context menu for setting position and Ctrl+scroll zooming with user guidance.

## Key Changes

- **Context Menu (`attachContextMenu`)**: Adds a right-click context menu that appears on desktop devices (hover-capable pointers). Clicking "Set position here" updates the marker location and triggers the `onMarkerDragEnd` callback. The menu intelligently repositions itself to stay within the viewport using the new `_clampMenuPos` utility.

- **Ctrl+Scroll Zoom**: Implements Ctrl/Cmd+scroll to zoom the map while preventing default scroll behavior. Plain scrolling shows a transient hint ("Use Ctrl + scroll to zoom") for 1.5 seconds to guide users, only on desktop pointer devices.

- **Viewport Clamping Utility (`_clampMenuPos`)**: New helper function that flips menu position left/up when it would overflow the viewport edges, with configurable estimated menu dimensions (defaults: 180×40px).

- **Leaflet Configuration**: Disabled `scrollWheelZoom` in map initialization to prevent conflicts with the custom scroll handling.

- **Styling**: Added CSS for the context menu (fixed positioning, white background, hover effects) and scroll hint (centered overlay with fade transition).

- **Tests**: Comprehensive test coverage for `_clampMenuPos` including edge cases (corner positioning, custom dimensions, exact viewport boundaries).

## Implementation Details

- Context menu uses `position: fixed` for viewport-relative positioning
- Menu visibility is toggled via CSS classes; click outside or press Escape to dismiss
- Scroll hint uses a timeout to auto-hide, preventing visual clutter
- Both features respect `(hover: hover) and (pointer: fine)` media query to avoid triggering on touch-only devices

https://claude.ai/code/session_019XVuX7mmdWQaFUWhRv443q