### PR TITLE
Add Farø Broen station to traffic map reference

### DIFF
--- a/station-names.json
+++ b/station-names.json
@@ -1,2 +1,3 @@
 {
+  "trafikkort:2018": "Farø Broen"
 }


### PR DESCRIPTION
## Summary
Added a new station entry to the station names mapping file to include Farø Broen with its traffic map reference identifier.

## Changes
- Added `"trafikkort:2018": "Farø Broen"` entry to station-names.json

## Details
This change registers Farø Broen station in the station names configuration, mapping it to the 2018 traffic map (trafikkort) reference system. This enables the station to be properly identified and referenced in traffic-related lookups and integrations.

https://claude.ai/code/session_01Vokyw9hCRspLfTd54eDtVv