### PR TITLE
Add support for custom station name overrides via fetchStationNames

### DIFF
--- a/app.js
+++ b/app.js
@@ -837,6 +837,17 @@ async function loadNearestObsStation(lat, lon) {
     }
     if (!obsHistory) throw new Error('obs-history unavailable');
 
+    let stationNames = window.STATION_NAMES;
+    if (!stationNames) {
+      try {
+        const fetchFn = window.fetchStationNames;
+        stationNames = fetchFn ? await fetchFn() : {};
+      } catch (_) {
+        stationNames = {};
+      }
+      window.STATION_NAMES = stationNames;
+    }
+
     // Haversine distance in km
     const R = 6371;
     const toRad = d => d * Math.PI / 180;
@@ -867,7 +878,7 @@ async function loadNearestObsStation(lat, lon) {
       if (window.highlightNearestStation) window.highlightNearestStation(null, null);
       _setObsStationHeader(null);
     } else {
-      const name = bestStation.name || bestKey;
+      const name = stationNames[bestKey] ?? bestStation.name ?? bestKey;
       window.DMI_OBS = {
         obs:         bestStation.obs,
         stationName: name,

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -136,6 +136,7 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
     drawShoreCompass:   null,
     analyseShore:       () => {},
     drawShoreDebug:     () => {},
+    fetchStationNames:  async () => ({}),
   });
 
   vm.runInContext(APP_SRC, ctx);
@@ -726,6 +727,22 @@ describe('loadNearestObsStation', () => {
     expect(capturedEl).not.toBeNull();
     expect(capturedEl.textContent).toContain('Near');
     expect(capturedEl.style.display).not.toBe('none');
+  });
+
+  it('applies station-names.json override in header and DMI_OBS.stationName', async () => {
+    const { ctx } = loadAppWithObs({ 'ninjo:near': nearStation });
+    ctx.window.STATION_NAMES = null;
+    ctx.window.fetchStationNames = async () => ({ 'ninjo:near': 'Custom Override Name' });
+    let capturedEl = null;
+    const origGet = ctx.document.getElementById.bind(ctx.document);
+    ctx.document.getElementById = (id) => {
+      const el = origGet(id);
+      if (id === 'obs-station-name') capturedEl = el;
+      return el;
+    };
+    await ctx.loadNearestObsStation(55.68, 12.57);
+    expect(capturedEl.textContent).toContain('Custom Override Name');
+    expect(ctx.window.DMI_OBS.stationName).toBe('Custom Override Name');
   });
 
   it('hides obs-station-name when no station is found', async () => {


### PR DESCRIPTION
## Summary
This change adds support for loading custom station name overrides from an external source, allowing station names to be customized without modifying the core station data.

## Key Changes
- Added `fetchStationNames` function support in `loadNearestObsStation()` to fetch custom station name mappings
- Implemented caching of station names in `window.STATION_NAMES` to avoid repeated fetches
- Updated station name resolution logic to prioritize custom overrides: `stationNames[bestKey] ?? bestStation.name ?? bestKey`
- Added error handling for `fetchStationNames` failures with graceful fallback to empty object
- Added test coverage for the station name override functionality

## Implementation Details
- The `fetchStationNames` function is called only once per session and cached in `window.STATION_NAMES`
- If `fetchStationNames` is not available or throws an error, the system falls back to using the original station names
- Custom station names are applied to both the UI header element and the `window.DMI_OBS.stationName` property
- The lookup uses the station key (e.g., 'ninjo:near') to find custom overrides in the fetched mapping

https://claude.ai/code/session_01RzSye6bs2ocVcgsedjUPz9