### PR TITLE
Add visual feedback for forecast reloads with updating state

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,8 +15,14 @@ function syncInvertedColorsClass() {
 ══════════════════════════════════════════════════ */
 async function load(cityName, model) {
   model = model || 'best_match';
-  document.getElementById('loading').style.display='block';
-  document.getElementById('forecast-content').style.display='none';
+  const forecastEl = document.getElementById('forecast-content');
+  const isReload = lastData !== null;
+  if (isReload) {
+    forecastEl.classList.add('updating');
+  } else {
+    document.getElementById('loading').style.display='block';
+    forecastEl.style.display='none';
+  }
   document.getElementById('error-msg').style.display='none';
   try {
     window.SHORE_MASK   = null;
@@ -152,7 +158,8 @@ async function load(cityName, model) {
     document.getElementById('updated-text').textContent =
       `Updated ${now.getDate()} ${DA_MON[now.getMonth()]} ${now.getFullYear()}`;
     document.getElementById('loading').style.display='none';
-    document.getElementById('forecast-content').style.display='block';
+    forecastEl.style.display='block';
+    forecastEl.classList.remove('updating');
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
@@ -181,6 +188,7 @@ async function load(cityName, model) {
   } catch(e) {
     console.error(e);
     document.getElementById('loading').style.display='none';
+    forecastEl.classList.remove('updating');
     document.getElementById('error-msg').style.display='block';
   }
 }
@@ -1416,9 +1424,15 @@ function setLoadingMsg(msg) {
  */
 async function loadAtCoords(lat, lon, model) {
   model = model || getModel();
-  document.getElementById('loading').style.display          = 'block';
-  document.getElementById('forecast-content').style.display = 'none';
-  document.getElementById('error-msg').style.display        = 'none';
+  const forecastEl = document.getElementById('forecast-content');
+  const isReload = lastData !== null;
+  if (isReload) {
+    forecastEl.classList.add('updating');
+  } else {
+    document.getElementById('loading').style.display = 'block';
+    forecastEl.style.display = 'none';
+  }
+  document.getElementById('error-msg').style.display = 'none';
   try {
     window.SHORE_MASK   = null;
     window.SHORE_STATUS = { state: 'loading', msg: 'Fetching coastline…' };
@@ -1547,8 +1561,9 @@ async function loadAtCoords(lat, lon, model) {
     const now=new Date();
     document.getElementById('updated-text').textContent =
       `Updated ${now.getDate()} ${DA_MON[now.getMonth()]} ${now.getFullYear()}`;
-    document.getElementById('loading').style.display          = 'none';
-    document.getElementById('forecast-content').style.display = 'block';
+    document.getElementById('loading').style.display = 'none';
+    forecastEl.style.display = 'block';
+    forecastEl.classList.remove('updating');
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
@@ -1581,8 +1596,9 @@ async function loadAtCoords(lat, lon, model) {
     loadNearestObsStation(lat, lon).catch(() => null);
   } catch(e) {
     console.error(e);
-    document.getElementById('loading').style.display          = 'none';
-    document.getElementById('error-msg').style.display        = 'block';
+    document.getElementById('loading').style.display = 'none';
+    forecastEl.classList.remove('updating');
+    document.getElementById('error-msg').style.display = 'block';
   }
 }
 

--- a/vejr.css
+++ b/vejr.css
@@ -129,6 +129,7 @@ canvas.main-canvas {
   width: 100%;
 }
 #loading { padding: 40px; text-align: center; font-size: 15px; color: #555; }
+#forecast-content.updating { opacity: 0.4; pointer-events: none; transition: opacity 0.15s; }
 #error-msg {
   padding: 20px 24px; color: #900; text-align: center;
   line-height: 1.7; display: none;


### PR DESCRIPTION
## Summary
This PR improves the user experience when reloading forecast data by adding visual feedback instead of showing a full loading screen. When data is already loaded and a refresh is triggered, the forecast content now fades to 40% opacity with a smooth transition while remaining interactive in the background.

## Key Changes
- **Visual feedback for reloads**: Added an `updating` CSS class that applies opacity and disables pointer events during data refresh
- **Smart loading state detection**: Both `load()` and `loadAtCoords()` functions now check if `lastData` exists to determine if this is a reload vs. initial load
- **Conditional UI behavior**: 
  - Initial load: Shows full loading screen and hides forecast content (existing behavior)
  - Reload: Applies subtle fade effect to existing forecast while fetching new data
- **Consistent state management**: Added `forecastEl.classList.remove('updating')` in error handlers to ensure the updating state is cleared even when requests fail
- **Code refactoring**: Extracted `forecast-content` element reference to reduce DOM queries and improve maintainability

## Implementation Details
- The `updating` class uses `opacity: 0.4` and `pointer-events: none` with a `0.15s` transition for smooth visual feedback
- Both data loading functions follow the same pattern: check `isReload = lastData !== null` and conditionally apply the updating state
- Error handlers properly clean up the updating state to prevent UI getting stuck in a faded state

https://claude.ai/code/session_01NGrwiQSEVZ5Ru3Mdn1Jarw