### PR TITLE
Use GitHub issue template for station name proposals

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -891,6 +891,9 @@ function _buildProposeNameUrl(s) {
                       if (place) {
                         const textEl = nameEl.querySelector('.stn-name-text') || nameEl;
                         textEl.textContent = place;
+                        sObj.name = place;
+                        const proposeEl = nameEl.querySelector('.stn-name-propose');
+                        if (proposeEl) proposeEl.href = _buildProposeNameUrl(sObj);
                         marker.getPopup()?.update();
                       }
                     }).catch(() => {});

--- a/radar.js
+++ b/radar.js
@@ -71,8 +71,7 @@ function _buildProposeNameUrl(s) {
     '?template=station-name.yml' +
     `&title=${encodeURIComponent(title)}` +
     `&station-key=${encodeURIComponent(s.key)}` +
-    `&current-name=${encodeURIComponent(s.name)}` +
-    `&proposed-name=${encodeURIComponent(s.name)}`
+    `&current-name=${encodeURIComponent(s.name)}`
   );
 }
 

--- a/radar.js
+++ b/radar.js
@@ -66,15 +66,12 @@ window.fetchStationNames = fetchStationNames;
  */
 function _buildProposeNameUrl(s) {
   const title = `Station name: ${s.key}`;
-  const body =
-    `**Station key:** ${s.key}\n` +
-    `**Proposed name:** [your suggestion here]\n` +
-    `**Current display name:** ${s.name}`;
   return (
     'https://github.com/ncvangilse/vejr/issues/new' +
-    '?labels=station-name' +
+    '?template=station-name.yml' +
     `&title=${encodeURIComponent(title)}` +
-    `&body=${encodeURIComponent(body)}`
+    `&station-key=${encodeURIComponent(s.key)}` +
+    `&current-name=${encodeURIComponent(s.name)}`
   );
 }
 

--- a/radar.js
+++ b/radar.js
@@ -71,7 +71,8 @@ function _buildProposeNameUrl(s) {
     '?template=station-name.yml' +
     `&title=${encodeURIComponent(title)}` +
     `&station-key=${encodeURIComponent(s.key)}` +
-    `&current-name=${encodeURIComponent(s.name)}`
+    `&current-name=${encodeURIComponent(s.name)}` +
+    `&proposed-name=${encodeURIComponent(s.name)}`
   );
 }
 

--- a/tests/radar.test.js
+++ b/tests/radar.test.js
@@ -188,6 +188,12 @@ describe('_buildProposeNameUrl', () => {
     expect(params.get('current-name')).toBe('Trafikkort 2047');
   });
 
+  it('pre-fills the proposed-name field with the geocoded display name', () => {
+    const url = _buildProposeNameUrl({ key: 'trafikkort:2047', name: 'Amager Strand' });
+    const params = new URL(url).searchParams;
+    expect(params.get('proposed-name')).toBe('Amager Strand');
+  });
+
   it('pre-fills the station-key field with the station key', () => {
     const url = _buildProposeNameUrl({ key: 'trafikkort:99', name: 'Some Name' });
     const params = new URL(url).searchParams;

--- a/tests/radar.test.js
+++ b/tests/radar.test.js
@@ -188,10 +188,10 @@ describe('_buildProposeNameUrl', () => {
     expect(params.get('current-name')).toBe('Trafikkort 2047');
   });
 
-  it('pre-fills the proposed-name field with the geocoded display name', () => {
+  it('does not pre-fill the proposed-name field', () => {
     const url = _buildProposeNameUrl({ key: 'trafikkort:2047', name: 'Amager Strand' });
     const params = new URL(url).searchParams;
-    expect(params.get('proposed-name')).toBe('Amager Strand');
+    expect(params.get('proposed-name')).toBeNull();
   });
 
   it('pre-fills the station-key field with the station key', () => {

--- a/tests/radar.test.js
+++ b/tests/radar.test.js
@@ -172,9 +172,9 @@ describe('_buildProposeNameUrl', () => {
     expect(url).toContain('https://github.com/ncvangilse/vejr/issues/new');
   });
 
-  it('includes the station-name label', () => {
+  it('uses the station-name issue template', () => {
     const url = _buildProposeNameUrl({ key: 'trafikkort:1018', name: 'Trafikkort 1018' });
-    expect(url).toContain('labels=station-name');
+    expect(url).toContain('template=station-name.yml');
   });
 
   it('encodes the station key in the title', () => {
@@ -182,21 +182,22 @@ describe('_buildProposeNameUrl', () => {
     expect(url).toContain(encodeURIComponent('trafikkort:1018'));
   });
 
-  it('encodes the current name in the body', () => {
+  it('pre-fills the current-name field with the display name', () => {
     const url = _buildProposeNameUrl({ key: 'trafikkort:2047', name: 'Trafikkort 2047' });
-    expect(url).toContain(encodeURIComponent('Trafikkort 2047'));
+    const params = new URL(url).searchParams;
+    expect(params.get('current-name')).toBe('Trafikkort 2047');
   });
 
-  it('body contains the station key', () => {
+  it('pre-fills the station-key field with the station key', () => {
     const url = _buildProposeNameUrl({ key: 'trafikkort:99', name: 'Some Name' });
     const params = new URL(url).searchParams;
-    expect(params.get('body')).toContain('trafikkort:99');
+    expect(params.get('station-key')).toBe('trafikkort:99');
   });
 
-  it('body contains placeholder for proposed name', () => {
+  it('sets the title to "Station name: <key>"', () => {
     const url = _buildProposeNameUrl({ key: 'trafikkort:1', name: 'X' });
     const params = new URL(url).searchParams;
-    expect(params.get('body')).toContain('[your suggestion here]');
+    expect(params.get('title')).toBe('Station name: trafikkort:1');
   });
 });
 


### PR DESCRIPTION
## Summary
Updated the station name proposal flow to use GitHub's issue template system instead of manually constructing the issue body. This leverages the `station-name.yml` template file to provide a structured form for users submitting station name suggestions.

## Key Changes
- Replaced `labels=station-name` query parameter with `template=station-name.yml` to use the dedicated issue template
- Removed manual body construction and replaced it with template-specific query parameters:
  - `station-key`: Pre-fills the station key field
  - `current-name`: Pre-fills the current display name field
- Updated test descriptions to reflect the new template-based approach and improved assertion specificity by using `searchParams` API instead of substring matching

## Implementation Details
The new approach delegates form structure and field definitions to the `station-name.yml` template file in the GitHub repository, making the form more maintainable and providing a better user experience through GitHub's native issue template UI.

https://claude.ai/code/session_01Ss9fabRDGjRrqNg1heVWfZ