### PR TITLE
Fix time and weekday label overlap in time axis

### DIFF
--- a/charts.js
+++ b/charts.js
@@ -72,13 +72,16 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
 
   // day segments & names
   const segs = [0,...divs,n];
+  ctx.font = `700 11px 'IBM Plex Sans', sans-serif`;
+  const dayLabels = [];
   for(let s=0;s<segs.length-1;s++){
     const midX = ((segs[s]+segs[s+1])/2) * colW;
+    const name = DA_DAYS[new Date(times[segs[s]]).getDay()];
+    dayLabels.push({ midX, halfW: ctx.measureText(name).width / 2 });
     ctx.fillStyle = textDay;
-    ctx.font = `700 11px 'IBM Plex Sans', sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(DA_DAYS[new Date(times[segs[s]]).getDay()], midX, TIME_H/2);
+    ctx.fillText(name, midX, TIME_H/2);
   }
 
   // Hour tick marks: every 3h for 1h-resolution data, every 6h for 3h-resolution data.
@@ -92,6 +95,7 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
     const h = new Date(t).getHours();
     if(h===0||h%tickEvery!==0) return;
     const x = (i+0.5)*colW;
+    if(dayLabels.some(dl => Math.abs(x - dl.midX) < dl.halfW + 4)) return;
     ctx.fillStyle = textHr;
     ctx.font = `10px 'IBM Plex Mono', monospace`;
     ctx.textAlign = 'center';


### PR DESCRIPTION
Hour tick labels (6, 12, 18) that fall within the bounds of a day
name label are now skipped, preventing visual overlap. Uses
ctx.measureText() for accurate per-label clearance.

Fixes #81

https://claude.ai/code/session_014hcw6gK6Pd9c9mxsppaf5c