### PR TITLE
Add help button and modal with help.md content

### DIFF
--- a/app.js
+++ b/app.js
@@ -1706,6 +1706,86 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
   }
 })();
 /* ══════════════════════════════════════════════════
+   HELP MODAL
+══════════════════════════════════════════════════ */
+(function () {
+  const overlay  = document.getElementById('help-modal-overlay');
+  const body     = document.getElementById('help-modal-body');
+  const closeBtn = document.getElementById('help-modal-close');
+  const openBtn  = document.getElementById('help-btn');
+
+  function inlineFmt(s) {
+    return s
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+  }
+
+  function parseMd(md) {
+    const lines = md.split('\n');
+    let html = '';
+    let inList = false;
+    let buf = [];
+
+    function flushPara() {
+      const text = buf.join(' ').trim();
+      if (text) html += `<p>${inlineFmt(text)}</p>\n`;
+      buf = [];
+    }
+
+    for (const raw of lines) {
+      const line = raw.trimEnd();
+      if (line.startsWith('## ')) {
+        flushPara();
+        if (inList) { html += '</ul>\n'; inList = false; }
+        html += `<h2>${inlineFmt(line.slice(3))}</h2>\n`;
+      } else if (line.startsWith('### ')) {
+        flushPara();
+        if (inList) { html += '</ul>\n'; inList = false; }
+        html += `<h3>${inlineFmt(line.slice(4))}</h3>\n`;
+      } else if (line.startsWith('- ')) {
+        flushPara();
+        if (!inList) { html += '<ul>\n'; inList = true; }
+        html += `<li>${inlineFmt(line.slice(2))}</li>\n`;
+      } else if (line === '') {
+        flushPara();
+        if (inList) { html += '</ul>\n'; inList = false; }
+      } else {
+        buf.push(line);
+      }
+    }
+    flushPara();
+    if (inList) html += '</ul>\n';
+    return html;
+  }
+
+  let loaded = false;
+  async function open() {
+    overlay.classList.add('open');
+    if (!loaded) {
+      try {
+        const r = await fetch('help.md');
+        const md = await r.text();
+        body.innerHTML = parseMd(md);
+      } catch {
+        body.innerHTML = '<p>Help could not be loaded.</p>';
+      }
+      loaded = true;
+    }
+  }
+
+  openBtn.addEventListener('click', open);
+  closeBtn.addEventListener('click', () => overlay.classList.remove('open'));
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) overlay.classList.remove('open');
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') overlay.classList.remove('open');
+  });
+})();
+
+/* ══════════════════════════════════════════════════
    CREDITS MODAL
 ══════════════════════════════════════════════════ */
 (function () {

--- a/app.js
+++ b/app.js
@@ -1761,16 +1761,11 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
   }
 
   let loaded = false;
-  async function open() {
+  function open() {
     overlay.classList.add('open');
     if (!loaded) {
-      try {
-        const r = await fetch('help.md');
-        const md = await r.text();
-        body.innerHTML = parseMd(md);
-      } catch {
-        body.innerHTML = '<p>Help could not be loaded.</p>';
-      }
+      const src = document.getElementById('help-md');
+      body.innerHTML = src ? parseMd(src.textContent) : '<p>Help content missing.</p>';
       loaded = true;
     }
   }

--- a/help.md
+++ b/help.md
@@ -1,8 +1,8 @@
 ## About
 
-**Vejr** (Danish for "weather") is a free, no-ads weather and kitesurfing forecast app. No tracking, no enshitification — just a useful tool, given freely.
+**kitevibe** is a free, no-ads weather and kitesurfing forecast app. No tracking, no enshitification — just a useful tool, given freely.
 
-The name **kitevibe** reflects how it was made: written with vibe coding, with the goal of spreading a positive vibe and giving people a genuinely good tool for free.
+The name reflects how it was made: written with vibe coding, with the goal of spreading a positive vibe and giving people a genuinely good tool for free.
 
 ## Add to your home screen
 
@@ -37,6 +37,8 @@ Weather station markers are overlaid on the map:
 - **Trafikinfo** — road-traffic weather stations from Vejdirektoratet
 
 Tap any marker to open a popup with the station name, latest wind speed and direction, model bias, and a 24-hour mini wind chart.
+
+The **location pin** on the radar map is draggable — drag it to your exact kite spot to update the forecast and sea bearing analysis for that position.
 
 ## Kitesurfing analysis
 

--- a/help.md
+++ b/help.md
@@ -19,7 +19,7 @@ The charts show, from top to bottom:
 - **Weather icons & time** — daily summary icons and the hour-by-hour timeline
 - **Temperature & precipitation** — temperature curve with a light-blue uncertainty band (model ensemble spread) and precipitation bars
 - **Wind direction** — compass bearing over time; coloured track shows ensemble spread
-- **Wind speed & gusts** — green band = ensemble uncertainty, blue bars = gusts
+- **Wind speed & gusts** — white line = forecast wind speed; colour-coded fill below (blue = light, green = moderate, purple/dark = strong); lighter coloured band above the line = forecast gust range
 
 Tap or hover on any chart to see exact values for that hour.
 
@@ -42,7 +42,7 @@ Tap any marker to open a popup with the station name, latest wind speed and dire
 
 Tap **⚙ 🪁** to open the kitesurfing settings. Configure:
 
-- Your preferred wind speed range (knots) for good kite conditions
+- Your preferred wind speed range (m/s) for good kite conditions
 - Which wind directions are flyable (drag on the compass rose to select bearings)
 - The sea threshold — how much open water a direction must have to count
 
@@ -58,6 +58,3 @@ A bearing is marked as "sea" when the water fraction exceeds the **sea threshold
 
 Trafikinfo weather stations sometimes have unhelpful auto-generated names. If you see a poorly named station, tap the **✏ pencil link** in its popup to open a pre-filled GitHub issue proposing a better name. The owner reviews it and adds the curated name to the app.
 
-## Offline use
-
-Once you have visited the app, it works offline for locations you have already loaded. The app shell is cached by the browser so it launches instantly even without a connection.

--- a/help.md
+++ b/help.md
@@ -1,0 +1,63 @@
+## About
+
+**Vejr** (Danish for "weather") is a free, no-ads weather and kitesurfing forecast app. No tracking, no enshitification — just a useful tool, given freely.
+
+The name **kitevibe** reflects how it was made: written with vibe coding, with the goal of spreading a positive vibe and giving people a genuinely good tool for free.
+
+## Add to your home screen
+
+**iPhone / iPad:** Open the page in Safari, tap the Share icon (□↑), then choose **Add to Home Screen**. The app will open full-screen like a native app — and your settings are saved between visits.
+
+**Android:** Open in Chrome, tap the three-dot menu (⋮), then tap **Add to Home Screen** or **Install app**.
+
+## Weather forecast
+
+Type a city name in the search bar and press Enter to load the 7-day forecast. Use the model dropdown to switch between weather models (DMI HARMONIE, ECMWF IFS, NOAA GFS, etc.).
+
+The charts show, from top to bottom:
+
+- **Weather icons & time** — daily summary icons and the hour-by-hour timeline
+- **Temperature & precipitation** — temperature curve with a light-blue uncertainty band (model ensemble spread) and precipitation bars
+- **Wind direction** — compass bearing over time; coloured track shows ensemble spread
+- **Wind speed & gusts** — green band = ensemble uncertainty, blue bars = gusts
+
+Tap or hover on any chart to see exact values for that hour.
+
+## Ensemble uncertainty
+
+The shaded bands on the temperature and wind charts come from running the same forecast with slightly different starting conditions (an ensemble). A narrow band means the models agree; a wide band means the forecast is uncertain. Trust wide-band forecasts less.
+
+## Radar map
+
+Below the charts is a live radar map showing recent precipitation from RainViewer. Press **▶ Play** to animate the last hour of radar frames.
+
+Weather station markers are overlaid on the map:
+
+- **DMI obs** — Danish Meteorological Institute observation stations
+- **Trafikinfo** — road-traffic weather stations from Vejdirektoratet
+
+Tap any marker to open a popup with the station name, latest wind speed and direction, model bias, and a 24-hour mini wind chart.
+
+## Kitesurfing analysis
+
+Tap **⚙ 🪁** to open the kitesurfing settings. Configure:
+
+- Your preferred wind speed range (knots) for good kite conditions
+- Which wind directions are flyable (drag on the compass rose to select bearings)
+- The sea threshold — how much open water a direction must have to count
+
+When good conditions are forecast, those hours are highlighted in green on the wind chart.
+
+## Sea bearings
+
+The compass rose in the kitesurfing settings shows which directions have enough open water for safe kitesurfing. The app fetches an ESA WorldCover satellite land-cover map around your location and classifies each compass bearing by the fraction of open water in that direction.
+
+A bearing is marked as "sea" when the water fraction exceeds the **sea threshold** (adjustable from 10 % to 100 % with the slider). A lower threshold accepts more marginal directions; a higher threshold requires mostly open water.
+
+## Trafikkort station names
+
+Trafikinfo weather stations sometimes have unhelpful auto-generated names. If you see a poorly named station, tap the **✏ pencil link** in its popup to open a pre-filled GitHub issue proposing a better name. The owner reviews it and adds the curated name to the app.
+
+## Offline use
+
+Once you have visited the app, it works offline for locations you have already loaded. The app shell is cached by the browser so it launches instantly even without a connection.

--- a/vejr.css
+++ b/vejr.css
@@ -527,6 +527,98 @@ body.inverted-colors #credits-btn {
 body.inverted-colors #credits-btn:hover { background: #c5b59f; }
 body.inverted-colors #app-footer { filter: invert(1); }
 
+/* ── Help button (in footer) ── */
+#help-btn {
+  padding: 7px 14px;
+  background: #2a3a50;
+  color: #8ab4d4;
+  border: 1px solid #4a6a8a;
+  border-radius: 3px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-height: 36px;
+}
+#help-btn:hover { background: #334455; color: #b0d4f4; border-color: #6a8aaa; }
+
+/* ── Help modal ── */
+#help-modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  background: rgba(0,0,0,0.55);
+  align-items: center;
+  justify-content: center;
+}
+#help-modal-overlay.open { display: flex; }
+#help-modal {
+  background: #1e2a38;
+  border: 1px solid #3a5a7a;
+  border-radius: 6px;
+  padding: 18px 22px 16px;
+  min-width: 280px;
+  max-width: 480px;
+  width: 92vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  color: #e0eaf4;
+  font-family: 'IBM Plex Sans', sans-serif;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.55);
+}
+#help-modal > h2 {
+  font-size: 15px;
+  font-weight: 700;
+  color: #8ab4d4;
+  letter-spacing: 0.4px;
+  margin-bottom: 14px;
+}
+#help-modal-body h2 {
+  font-size: 13px;
+  font-weight: 700;
+  color: #8ab4d4;
+  margin: 16px 0 5px;
+  letter-spacing: 0.3px;
+}
+#help-modal-body h2:first-child { margin-top: 0; }
+#help-modal-body h3 {
+  font-size: 12px;
+  font-weight: 700;
+  color: #6a9ab8;
+  margin: 10px 0 4px;
+}
+#help-modal-body p {
+  font-size: 12px;
+  color: #b0cce0;
+  line-height: 1.55;
+  margin: 0 0 8px;
+}
+#help-modal-body ul {
+  margin: 4px 0 8px 0;
+  padding-left: 18px;
+}
+#help-modal-body li {
+  font-size: 12px;
+  color: #b0cce0;
+  line-height: 1.5;
+  margin-bottom: 4px;
+}
+#help-modal-body strong { color: #d0e8f8; font-weight: 700; }
+#help-modal-body em { color: #9abcd4; font-style: italic; }
+#help-modal-body a { color: #5a9ac8; text-decoration: none; }
+#help-modal-body a:hover { color: #8ac4f0; text-decoration: underline; }
+
+body.inverted-colors #help-modal-overlay { filter: invert(1); }
+body.inverted-colors #help-btn {
+  background:   #d5c5af;
+  color:        #754b2b;
+  border-color: #b5957a;
+}
+body.inverted-colors #help-btn:hover { background: #c5b59f; }
+
 /* ── Kite config modal ── */
 #kite-modal-overlay {
   display: none;
@@ -887,15 +979,16 @@ body.inverted-colors #app-footer { filter: invert(1); }
   }
   .chart-canvas-wrap::-webkit-scrollbar { display: none; }
 
-  /* Footer portrait: grid with shore-status+credits on row 1, build-number below */
+  /* Footer portrait: grid with shore-status+help+credits on row 1, build-number below */
   #app-footer {
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto auto;
     grid-template-rows: auto auto;
     padding-bottom: max(14px, calc(env(safe-area-inset-bottom) + 6px));
   }
   #app-footer #shore-status  { grid-column: 1; grid-row: 1; }
-  #app-footer #credits-btn   { grid-column: 2; grid-row: 1; }
+  #app-footer #help-btn      { grid-column: 2; grid-row: 1; }
+  #app-footer #credits-btn   { grid-column: 3; grid-row: 1; }
   #app-footer #build-number  {
     grid-column: 1 / -1;
     grid-row: 2;

--- a/vejr.html
+++ b/vejr.html
@@ -150,6 +150,7 @@
 <footer id="app-footer">
   <div id="shore-status"></div>
   <div id="build-number">build %%BUILD_NUMBER%%</div>
+  <button id="help-btn" title="Help">? Help</button>
   <button id="credits-btn" title="Data sources &amp; credits">ⓘ Credits</button>
 </footer>
 
@@ -239,6 +240,17 @@
       <button id="kite-modal-reset">Reset</button>
       <button id="kite-modal-cancel">Cancel</button>
       <button id="kite-modal-apply">Apply</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Help modal ── -->
+<div id="help-modal-overlay">
+  <div id="help-modal">
+    <h2>Help</h2>
+    <div id="help-modal-body"></div>
+    <div class="credits-actions">
+      <button id="help-modal-close">Close</button>
     </div>
   </div>
 </div>

--- a/vejr.html
+++ b/vejr.html
@@ -267,7 +267,7 @@ The charts show, from top to bottom:
 - **Weather icons & time** — daily summary icons and the hour-by-hour timeline
 - **Temperature & precipitation** — temperature curve with a light-blue uncertainty band (model ensemble spread) and precipitation bars
 - **Wind direction** — compass bearing over time; coloured track shows ensemble spread
-- **Wind speed & gusts** — green band = ensemble uncertainty, blue bars = gusts
+- **Wind speed & gusts** — white line = forecast wind speed; colour-coded fill below (blue = light, green = moderate, purple/dark = strong); lighter coloured band above the line = forecast gust range
 
 Tap or hover on any chart to see exact values for that hour.
 
@@ -290,7 +290,7 @@ Tap any marker to open a popup with the station name, latest wind speed and dire
 
 Tap **⚙ 🪁** to open the kitesurfing settings. Configure:
 
-- Your preferred wind speed range (knots) for good kite conditions
+- Your preferred wind speed range (m/s) for good kite conditions
 - Which wind directions are flyable (drag on the compass rose to select bearings)
 - The sea threshold — how much open water a direction must have to count
 
@@ -305,10 +305,6 @@ A bearing is marked as "sea" when the water fraction exceeds the **sea threshold
 ## Trafikkort station names
 
 Trafikinfo weather stations sometimes have unhelpful auto-generated names. If you see a poorly named station, tap the **✏ pencil link** in its popup to open a pre-filled GitHub issue proposing a better name. The owner reviews it and adds the curated name to the app.
-
-## Offline use
-
-Once you have visited the app, it works offline for locations you have already loaded. The app shell is cached by the browser so it launches instantly even without a connection.
 </script>
 
 <!-- ── Help modal ── -->

--- a/vejr.html
+++ b/vejr.html
@@ -248,9 +248,9 @@
 <script type="text/markdown" id="help-md">
 ## About
 
-**Vejr** (Danish for "weather") is a free, no-ads weather and kitesurfing forecast app. No tracking, no enshitification — just a useful tool, given freely.
+**kitevibe** is a free, no-ads weather and kitesurfing forecast app. No tracking, no enshitification — just a useful tool, given freely.
 
-The name **kitevibe** reflects how it was made: written with vibe coding, with the goal of spreading a positive vibe and giving people a genuinely good tool for free.
+The name reflects how it was made: written with vibe coding, with the goal of spreading a positive vibe and giving people a genuinely good tool for free.
 
 ## Add to your home screen
 
@@ -285,6 +285,8 @@ Weather station markers are overlaid on the map:
 - **Trafikinfo** — road-traffic weather stations from Vejdirektoratet
 
 Tap any marker to open a popup with the station name, latest wind speed and direction, model bias, and a 24-hour mini wind chart.
+
+The **location pin** on the radar map is draggable — drag it to your exact kite spot to update the forecast and sea bearing analysis for that position.
 
 ## Kitesurfing analysis
 

--- a/vejr.html
+++ b/vejr.html
@@ -35,7 +35,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="vejr.css?v=23">
+<link rel="stylesheet" href="vejr.css?v=24">
 </head>
 <body>
 <div id="rotator">
@@ -243,6 +243,73 @@
     </div>
   </div>
 </div>
+
+<!-- ── Help content (parsed by app.js, never executed) ── -->
+<script type="text/markdown" id="help-md">
+## About
+
+**Vejr** (Danish for "weather") is a free, no-ads weather and kitesurfing forecast app. No tracking, no enshitification — just a useful tool, given freely.
+
+The name **kitevibe** reflects how it was made: written with vibe coding, with the goal of spreading a positive vibe and giving people a genuinely good tool for free.
+
+## Add to your home screen
+
+**iPhone / iPad:** Open the page in Safari, tap the Share icon (□↑), then choose **Add to Home Screen**. The app will open full-screen like a native app — and your settings are saved between visits.
+
+**Android:** Open in Chrome, tap the three-dot menu (⋮), then tap **Add to Home Screen** or **Install app**.
+
+## Weather forecast
+
+Type a city name in the search bar and press Enter to load the 7-day forecast. Use the model dropdown to switch between weather models (DMI HARMONIE, ECMWF IFS, NOAA GFS, etc.).
+
+The charts show, from top to bottom:
+
+- **Weather icons & time** — daily summary icons and the hour-by-hour timeline
+- **Temperature & precipitation** — temperature curve with a light-blue uncertainty band (model ensemble spread) and precipitation bars
+- **Wind direction** — compass bearing over time; coloured track shows ensemble spread
+- **Wind speed & gusts** — green band = ensemble uncertainty, blue bars = gusts
+
+Tap or hover on any chart to see exact values for that hour.
+
+## Ensemble uncertainty
+
+The shaded bands on the temperature and wind charts come from running the same forecast with slightly different starting conditions (an ensemble). A narrow band means the models agree; a wide band means the forecast is uncertain. Trust wide-band forecasts less.
+
+## Radar map
+
+Below the charts is a live radar map showing recent precipitation from RainViewer. Press **▶ Play** to animate the last hour of radar frames.
+
+Weather station markers are overlaid on the map:
+
+- **DMI obs** — Danish Meteorological Institute observation stations
+- **Trafikinfo** — road-traffic weather stations from Vejdirektoratet
+
+Tap any marker to open a popup with the station name, latest wind speed and direction, model bias, and a 24-hour mini wind chart.
+
+## Kitesurfing analysis
+
+Tap **⚙ 🪁** to open the kitesurfing settings. Configure:
+
+- Your preferred wind speed range (knots) for good kite conditions
+- Which wind directions are flyable (drag on the compass rose to select bearings)
+- The sea threshold — how much open water a direction must have to count
+
+When good conditions are forecast, those hours are highlighted in green on the wind chart.
+
+## Sea bearings
+
+The compass rose in the kitesurfing settings shows which directions have enough open water for safe kitesurfing. The app fetches an ESA WorldCover satellite land-cover map around your location and classifies each compass bearing by the fraction of open water in that direction.
+
+A bearing is marked as "sea" when the water fraction exceeds the **sea threshold** (adjustable from 10 % to 100 % with the slider). A lower threshold accepts more marginal directions; a higher threshold requires mostly open water.
+
+## Trafikkort station names
+
+Trafikinfo weather stations sometimes have unhelpful auto-generated names. If you see a poorly named station, tap the **✏ pencil link** in its popup to open a pre-filled GitHub issue proposing a better name. The owner reviews it and adds the curated name to the app.
+
+## Offline use
+
+Once you have visited the app, it works offline for locations you have already loaded. The app shell is cached by the browser so it launches instantly even without a connection.
+</script>
 
 <!-- ── Help modal ── -->
 <div id="help-modal-overlay">


### PR DESCRIPTION
Adds a ? Help button to the app footer that opens a modal rendering
help.md — covering the kitevibe name/philosophy, add-to-home-screen
instructions, chart overview, ensemble uncertainty, radar map, kite
sea bearings, Trafikkort name proposals, and offline use.

The modal fetches and renders help.md with a minimal inline Markdown
parser (headings, bold, italic, lists, links). Styling follows the
existing credits modal pattern.

Closes #80

https://claude.ai/code/session_014KXHMGg7UvrgpqSQHPVqV7