### PR TITLE
Add MIT license and remove custom User-Agent header

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ncvangilse <info@kitevibe.dk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/fetch-ninjo.py
+++ b/scripts/fetch-ninjo.py
@@ -70,7 +70,6 @@ import pandas as pd
 # ── Source URLs ────────────────────────────────────────────────────────────────
 NINJO_URL   = ('https://www.dmi.dk/NinJo2DmiDk/ninjo2dmidk'
                '?cmd=obj&south=54.1&north=57.9&west=5.5&east=17.9')
-NINJO_HDRS  = {'User-Agent': 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36'}
 TRAFIKK_URL = ('https://storage.googleapis.com/trafikkort-data'
                '/geojson/wind-speeds.point.json')
 OPEN_METEO  = 'https://api.open-meteo.com/v1/forecast'
@@ -470,7 +469,7 @@ class FetchNinjo(hass.Hass):
                 sha_map = await self._get_sha_map(session, gh_headers)
 
                 ninjo_raw, trafikk_raw = await asyncio.gather(
-                    self._fetch_json(session, NINJO_URL,   NINJO_HDRS, 'NinJo'),
+                    self._fetch_json(session, NINJO_URL,   {},          'NinJo'),
                     self._fetch_json(session, TRAFIKK_URL, {},          'Trafikkort'),
                 )
 


### PR DESCRIPTION
## Summary
This PR adds an MIT license to the project and removes a custom User-Agent header that was previously used for NinJo API requests.

## Changes
- **Added LICENSE file**: MIT license with copyright holder ncvangilse
- **Removed custom User-Agent header**: Deleted the `NINJO_HDRS` constant that contained a custom Mozilla User-Agent string
- **Updated NinJo API call**: Changed the `_fetch_json()` call for NinJo to use an empty headers dictionary (`{}`) instead of the removed `NINJO_HDRS`

## Details
The removal of the custom User-Agent header simplifies the code by relying on the default User-Agent behavior of the HTTP client. This change suggests either that the custom header was unnecessary for the API to function properly, or that the API no longer requires it.

https://claude.ai/code/session_011nMxFWSKiQ7c8A3qyeorwb