### PR TITLE
Add cache busting query parameters to app icons

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -2,10 +2,10 @@ const CACHE_NAME = 'vejr-%%BUILD_NUMBER%%-5';
 
 // Only cache truly static assets — never the HTML or SW itself
 const ASSETS = [
-  'icon-assets/icon-120.png',
-  'icon-assets/icon-152.png',
-  'icon-assets/icon-167.png',
-  'icon-assets/icon-180.png',
+  'icon-assets/icon-120.png?v=2',
+  'icon-assets/icon-152.png?v=2',
+  'icon-assets/icon-167.png?v=2',
+  'icon-assets/icon-180.png?v=2',
   'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@400;600;700&display=swap'
 ];
 

--- a/vejr.html
+++ b/vejr.html
@@ -24,11 +24,11 @@
 <meta name="theme-color" content="#003c8f">
 
 <!-- iOS home screen icons -->
-<link rel="apple-touch-icon" href="icon-assets/icon-180.png">
-<link rel="apple-touch-icon" sizes="120x120" href="icon-assets/icon-120.png">
-<link rel="apple-touch-icon" sizes="152x152" href="icon-assets/icon-152.png">
-<link rel="apple-touch-icon" sizes="167x167" href="icon-assets/icon-167.png">
-<link rel="apple-touch-icon" sizes="180x180" href="icon-assets/icon-180.png">
+<link rel="apple-touch-icon" href="icon-assets/icon-180.png?v=2">
+<link rel="apple-touch-icon" sizes="120x120" href="icon-assets/icon-120.png?v=2">
+<link rel="apple-touch-icon" sizes="152x152" href="icon-assets/icon-152.png?v=2">
+<link rel="apple-touch-icon" sizes="167x167" href="icon-assets/icon-167.png?v=2">
+<link rel="apple-touch-icon" sizes="180x180" href="icon-assets/icon-180.png?v=2">
 
 <!-- Leaflet (used for RainViewer radar map) -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>


### PR DESCRIPTION
## Summary
Added version query parameters (`?v=2`) to all app icon asset URLs to enable cache busting and ensure users receive updated icons when they're modified.

## Changes
- Updated all iOS home screen icon links in `vejr.html` to include `?v=2` query parameter
- Updated corresponding icon asset URLs in the service worker cache list (`sw.js`) with matching `?v=2` query parameter
- Affected icons: `icon-120.png`, `icon-152.png`, `icon-167.png`, and `icon-180.png`

## Implementation Details
The query parameter approach allows browsers and service workers to treat updated icon files as new resources, bypassing cached versions. This ensures that when icon assets are updated, users will see the new versions rather than stale cached copies. The version number can be incremented in future updates to invalidate the cache again if needed.

https://claude.ai/code/session_01PFfBbGmLKB8PfCiffFcMpH