### PR TITLE
Remove radar frame labels and move station toggles below map (issue #91)

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -608,17 +608,17 @@ function _buildProposeNameUrl(s) {
   function _fitRadarHeight() {
     const section    = document.getElementById('radar-section');
     const mapEl      = document.getElementById('radar-map');
-    const headerEl   = document.getElementById('radar-header');
     const controlsEl = document.getElementById('radar-controls');
+    const obsEl      = document.getElementById('radar-obs-controls');
     if (!section || section.style.display === 'none') return;
-    const headerH   = headerEl   ? headerEl.offsetHeight   : 34;
     const controlsH = controlsEl ? controlsEl.offsetHeight : 34;
+    const obsH      = obsEl      ? obsEl.offsetHeight      : 34;
     // section.offsetTop = distance from document top to section border-box.
     // footer has margin-top: 12px.  We want footer-top = window.innerHeight
     // (just below fold) when scrollY = 0, so:
     //   section.offsetTop + sectionHeight + 12 = window.innerHeight
-    //   mapHeight = window.innerHeight - section.offsetTop - 12 - headerH - controlsH - 2 (borders)
-    const mapH = window.innerHeight - section.offsetTop - 12 - headerH - controlsH - 2;
+    //   mapHeight = window.innerHeight - section.offsetTop - 12 - controlsH - obsH - 2 (borders)
+    const mapH = window.innerHeight - section.offsetTop - 12 - controlsH - obsH - 2;
     mapEl.style.minHeight = Math.max(320, mapH) + 'px';
   }
 

--- a/vejr.css
+++ b/vejr.css
@@ -242,30 +242,14 @@ canvas.main-canvas {
   display: none;
   flex-direction: column;
 }
-#radar-header {
-  background: #d8dfe8;
-  border-bottom: 1px solid #a8b0b8;
-  padding: 7px 12px;
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 0.2px;
+#radar-obs-controls {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  padding: 6px 10px;
+  background: #d8dfe8;
+  border-top: 1px solid #a8b0b8;
   flex-shrink: 0;
 }
-#radar-header span { font-size: 10px; font-weight: 400; color: #667; }
-#radar-tile-counter {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 10px;
-  color: #334;
-  background: rgba(0,0,0,0.08);
-  padding: 2px 6px;
-  border-radius: 3px;
-  transition: color 0.3s;
-}
-#radar-tile-counter.warn  { color: #c07000; background: rgba(192,112,0,0.12); }
-#radar-tile-counter.limit { color: #cc2200; background: rgba(204,34,0,0.12); font-weight: 700; }
 #radar-map {
   width: 100%;
   flex: 1;

--- a/vejr.html
+++ b/vejr.html
@@ -130,16 +130,6 @@
 
 <!-- ── RainViewer Radar ────────────────────────────────────────────── -->
 <div id="radar-section">
-  <div id="radar-header">
-    <span style="font-size:13px;font-weight:700;letter-spacing:0.2px;color:#111;">Radar – precipitation</span>
-    <span id="radar-tile-counter" title="Tile requests today (max ~1000)">0 / 1000 tiles</span>
-    <div class="radar-stations-group">
-      <span class="radar-stations-label">📡 Stations</span>
-      <button id="radar-trafikinfo-toggle" class="radar-overlay-toggle active" title="Toggle Trafikkort wind station overlay">Trafikinfo</button>
-      <button id="radar-dmi-toggle" class="radar-overlay-toggle active" title="Toggle DMI observation overlay">DMI obs</button>
-    </div>
-    <span id="radar-source-label">RainViewer</span>
-  </div>
   <div id="radar-map">
     <div id="radar-loading">Loading radar…</div>
   </div>
@@ -149,6 +139,13 @@
     <div id="radar-time-label">—</div>
     <button class="radar-zoom-btn" id="radar-zoom-in"  title="Zoom in">+</button>
     <button class="radar-zoom-btn" id="radar-zoom-out" title="Zoom out">−</button>
+  </div>
+  <div id="radar-obs-controls">
+    <div class="radar-stations-group">
+      <span class="radar-stations-label">📡 Stations</span>
+      <button id="radar-trafikinfo-toggle" class="radar-overlay-toggle active" title="Toggle Trafikkort wind station overlay">Trafikinfo</button>
+      <button id="radar-dmi-toggle" class="radar-overlay-toggle active" title="Toggle DMI observation overlay">DMI obs</button>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
Drop "Radar – precipitation" title, tile counter, and "RainViewer" source label
from the radar header, and remove the now-empty header element entirely.
Move the obs-point station toggles (Trafikinfo / DMI obs) to a new
#radar-obs-controls row below the playback controls.

https://claude.ai/code/session_01LHjoEdNggenoRqW363aw4s