### PR TITLE
Fix iOS Home Screen location not persisting after pin drag (issue #89)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1442,6 +1442,13 @@ async function loadAtCoords(lat, lon, model) {
     if (window.fetchShoreVector) window.fetchShoreVector(lat, lon).catch(() => null);
     if (window.analyseShore)     window.analyseShore(lat, lon).catch(() => null);
 
+    // Persist coords before any awaits: both a page reload and an iOS Home
+    // Screen launch (which always opens the manifest start_url without query
+    // params) must be able to restore the exact position from localStorage.
+    const coordStr = `${lat.toFixed(6)},${lon.toFixed(6)}`;
+    setQParam(coordStr);
+    try { localStorage.setItem('vejr_city', coordStr); } catch(_) {}
+
     // Reverse-geocode for a human-readable name (best-effort)
     let displayName = `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
     let reverseCountryCode = null;
@@ -1459,8 +1466,6 @@ async function loadAtCoords(lat, lon, model) {
     } catch(_) { /* keep coord string */ }
 
     document.getElementById('city-input').value = displayName;
-    // Store coords in the URL so a page reload restores the exact dragged position
-    setQParam(`${lat.toFixed(6)},${lon.toFixed(6)}`);
 
     const iconCodeFetch = (model === 'dmi_seamless')
       ? fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=weathercode&forecast_days=${FORECAST_DAYS}&timezone=auto&models=icon_seamless`)
@@ -1621,7 +1626,11 @@ async function loadByCoords(lat, lon, model) {
     }
   } catch(e) { /* keep coordinate fallback */ }
   document.getElementById('city-input').value = displayName;
-  setQParam(displayName);
+  // Persist coords (not the display name) so an iOS Home Screen launch restores
+  // the exact GPS-detected position instead of re-geocoding a city name.
+  const coordStr = `${lat.toFixed(6)},${lon.toFixed(6)}`;
+  setQParam(coordStr);
+  try { localStorage.setItem('vejr_city', coordStr); } catch(_) {}
   await load(displayName, model);
 }
 async function tryGeolocation(model) {
@@ -1722,9 +1731,17 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
   } else if (decision.type === 'geolocation') {
     tryGeolocation(model);
   } else {
-    document.getElementById('city-input').value = decision.value;
-    setQParam(decision.value);
-    load(decision.value, model);
+    // saved or typed — if the stored value is a "lat,lon" coord string (written
+    // by loadAtCoords / loadByCoords to survive iOS Home Screen launches), restore
+    // the exact coordinates instead of sending them through geocoding.
+    const coordMatch = decision.value.match(/^(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)$/);
+    if (coordMatch) {
+      loadAtCoords(parseFloat(coordMatch[1]), parseFloat(coordMatch[2]), model);
+    } else {
+      document.getElementById('city-input').value = decision.value;
+      setQParam(decision.value);
+      load(decision.value, model);
+    }
   }
 })();
 /* ══════════════════════════════════════════════════

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -238,6 +238,70 @@ describe('loadAndSync', () => {
   });
 });
 
+// ── iOS Home Screen location persistence ─────────────────────────────────────
+// When the user drags the radar pin (loadAtCoords) or GPS detects a location
+// (loadByCoords), the exact coords must be written to localStorage so that an
+// iOS Home Screen launch — which always opens the manifest start_url with no
+// query params — can restore the position without going through geocoding.
+
+describe('loadAtCoords – persists coords to localStorage', () => {
+  it('writes lat/lon string to vejr_city in localStorage', () => {
+    const { ctx, mockLocalStorage } = loadApp();
+    ctx.loadAtCoords(55.123456, 12.654321, 'dmi_seamless');
+    expect(mockLocalStorage.store['vejr_city']).toBe('55.123456,12.654321');
+  });
+
+  it('overwrites a previously saved city name with the new coords', () => {
+    const { ctx, mockLocalStorage } = loadApp({ savedCity: 'Berlin' });
+    ctx.loadAtCoords(55.0, 12.0, 'dmi_seamless');
+    expect(mockLocalStorage.store['vejr_city']).toBe('55.000000,12.000000');
+  });
+
+  it('also updates the URL q param with the coord string', () => {
+    const { ctx, replaceStateCalls } = loadApp();
+    ctx.loadAtCoords(55.123456, 12.654321, 'dmi_seamless');
+    const lastUrl = replaceStateCalls.at(-1)[2];
+    expect(lastUrl).toContain('55.123456');
+    expect(lastUrl).toContain('12.654321');
+  });
+});
+
+describe('initialLoad – restores saved coord string without geocoding (iOS Home Screen)', () => {
+  it('calls loadAtCoords path when savedCity is a lat/lon string', async () => {
+    // When iOS opens the app from the Home Screen shortcut the URL has no ?q=
+    // param. The only location data is the coord string stored in localStorage.
+    // The app must restore coords directly — not pass them to geocode().
+    const geocodeCalls = [];
+    const { replaceStateCalls } = loadApp({
+      savedCity: '55.123456,12.654321',
+      // Override geocode stub to track whether it is called.
+    });
+    // Allow the async loadAtCoords chain to start (fetch rejects immediately,
+    // but setQParam is called synchronously before the first await).
+    await new Promise(r => setTimeout(r, 0));
+    // The URL should be updated with the coord string (not a geocoded city name).
+    const lastUrl = replaceStateCalls.at(-1)?.[2] ?? '';
+    expect(lastUrl).toContain('55.123456');
+    expect(lastUrl).toContain('12.654321');
+  });
+
+  it('does not treat a coord string as a city name to geocode', () => {
+    // If geocode were called with a coord string it would hit external APIs and
+    // likely fail.  We verify city-input.value is NOT set to the raw coord string
+    // (loadAtCoords sets it to the reverse-geocoded name or coord fallback, but
+    // never leaves it as the raw "lat,lon" storage key).
+    const { cityInput } = loadApp({ savedCity: '55.123456,12.654321' });
+    // city-input must NOT have been naively set to the raw storage value.
+    expect(cityInput.value).not.toBe('55.123456,12.654321');
+  });
+
+  it('still geocodes a normal city name saved in localStorage', () => {
+    const { cityInput, geoCalls } = loadApp({ savedCity: 'Berlin', geoAvailable: true });
+    expect(cityInput.value).toBe('Berlin');
+    expect(geoCalls).toHaveLength(0); // geolocation not triggered (saved city used)
+  });
+});
+
 // ── HTML structure ────────────────────────────────────────────────────────────
 
 describe('vejr.html structure', () => {


### PR DESCRIPTION
The manifest start_url is /vejr.html (no query params), so iOS always
opens the app from that fixed URL regardless of what replaceState wrote.
Only localStorage survives across Home Screen launches.

- loadAtCoords: persist coordStr to localStorage *before* any await so
  the value is immediately available even if the weather fetch fails
- loadByCoords (GPS path): likewise store lat/lon string in localStorage
  instead of the reverse-geocoded city name
- initialLoad (saved/typed branch): recognise a stored "lat,lon" value
  and call loadAtCoords directly instead of passing it to geocode()

Tests: three new describe blocks covering the localStorage write, the
overwrite of a previous city, and the iOS Home Screen restore path.

https://claude.ai/code/session_01PajBTW8gWNp3TUePShxvsk