### PR TITLE
Add feedback mailto link to footer

### DIFF
--- a/vejr.css
+++ b/vejr.css
@@ -457,6 +457,17 @@ canvas.main-canvas {
 }
 #credits-btn:hover { background: #334455; color: #b0d4f4; border-color: #6a8aaa; }
 
+/* ── Feedback mailto link (in footer) ── */
+#feedback-link {
+  font-size: 11px;
+  color: #667;
+  font-family: 'IBM Plex Mono', monospace;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+#feedback-link:hover { color: #8ab4d4; text-decoration: underline; }
+
 /* ── Credits modal ── */
 #credits-modal-overlay {
   display: none;
@@ -1026,10 +1037,16 @@ body.inverted-colors #help-btn:hover { background: #c5b59f; }
   #app-footer #help-btn      { grid-column: 2; grid-row: 1; }
   #app-footer #credits-btn   { grid-column: 3; grid-row: 1; }
   #app-footer #build-number  {
-    grid-column: 1 / -1;
+    grid-column: 1;
     grid-row: 2;
     white-space: normal;
     margin-top: 4px;
+  }
+  #app-footer #feedback-link {
+    grid-column: 2 / -1;
+    grid-row: 2;
+    margin-top: 4px;
+    text-align: right;
   }
 }
 

--- a/vejr.html
+++ b/vejr.html
@@ -154,6 +154,7 @@
   <div id="build-number">build %%BUILD_NUMBER%%</div>
   <button id="help-btn" title="Help">? Help</button>
   <button id="credits-btn" title="Data sources &amp; credits">ⓘ Credits</button>
+  <a href="mailto:info@kitevibe.dk" id="feedback-link">Feedback</a>
 </footer>
 
 </div> <!-- #rotator -->


### PR DESCRIPTION
## Summary
Added a feedback mailto link to the application footer, allowing users to easily contact the development team.

## Changes
- **HTML**: Added a new feedback link (`<a href="mailto:info@kitevibe.dk">`) in the footer next to the existing help and credits buttons
- **CSS**: 
  - Created new styling for `#feedback-link` with monospace font, subtle gray color, and hover effects
  - Updated footer grid layout to accommodate the new feedback link on the second row, right-aligned
  - Modified `#build-number` grid positioning from spanning full width to first column only

## Implementation Details
- The feedback link uses a mailto: protocol pointing to `info@kitevibe.dk`
- Styled with IBM Plex Mono font to match the technical aesthetic
- Hover state changes color to a light blue (`#8ab4d4`) with underline for visual feedback
- On smaller screens (responsive layout), the feedback link appears on the second row, right-aligned, while the build number moves to the first column
- Uses `flex-shrink: 0` and `white-space: nowrap` to prevent text wrapping

https://claude.ai/code/session_01AG17c3EsxyHHuiHrXP57HH