### PR TITLE
Extend forecast to 16 days with variable-resolution display

### DIFF
--- a/api.js
+++ b/api.js
@@ -69,13 +69,14 @@ async function fetchEnsemble(lat, lon, model) {
     'meteofrance_seamless':'icon_seamless',
     'gfs_seamless':        'gfs025',
   };
-  let ensModel = ENS_MAP[model] || 'icon_seamless';
-  // icon_seamless ensemble is capped at 7 days; fall back to ecmwf_ifs04 (15 days) for longer forecasts
-  if (FORECAST_DAYS > 7 && ensModel === 'icon_seamless') ensModel = 'ecmwf_ifs04';
+  const ensModel = ENS_MAP[model] || 'icon_seamless';
+  // Cap forecast_days to each ensemble model's supported maximum
+  const ENS_MAX_DAYS = { 'icon_seamless': 7, 'ecmwf_ifs04': 15, 'gfs025': 35 };
+  const ensDays = Math.min(FORECAST_DAYS, ENS_MAX_DAYS[ensModel] || 7);
   const url = `https://ensemble-api.open-meteo.com/v1/ensemble?latitude=${lat}&longitude=${lon}`
     + `&hourly=temperature_2m,windspeed_10m,windgusts_10m,precipitation`
     + `&models=${ensModel}`
-    + `&forecast_days=${FORECAST_DAYS}&timezone=auto&windspeed_unit=ms`;
+    + `&forecast_days=${ensDays}&timezone=auto&windspeed_unit=ms`;
   const r = await fetch(url);
   if (!r.ok) throw new Error('ensemble fetch failed');
   return r.json();

--- a/api.js
+++ b/api.js
@@ -69,7 +69,9 @@ async function fetchEnsemble(lat, lon, model) {
     'meteofrance_seamless':'icon_seamless',
     'gfs_seamless':        'gfs025',
   };
-  const ensModel = ENS_MAP[model] || 'icon_seamless';
+  let ensModel = ENS_MAP[model] || 'icon_seamless';
+  // icon_seamless ensemble is capped at 7 days; fall back to ecmwf_ifs04 (15 days) for longer forecasts
+  if (FORECAST_DAYS > 7 && ensModel === 'icon_seamless') ensModel = 'ecmwf_ifs04';
   const url = `https://ensemble-api.open-meteo.com/v1/ensemble?latitude=${lat}&longitude=${lon}`
     + `&hourly=temperature_2m,windspeed_10m,windgusts_10m,precipitation`
     + `&models=${ensModel}`

--- a/app.js
+++ b/app.js
@@ -345,6 +345,7 @@ function buildPortraitSeries(s) {
 
     // x-position mapping: each 1h point → CSS x-center on the display grid.
     xMap1h, xFrac1h, slotIdx1h,
+    isPortraitMode: true,
   };
 }
 
@@ -432,6 +433,7 @@ function buildLandscapeSeries(s, colW) {
     ensGust1h:   s.ensGust1h, ensPrecip1h: s.ensPrecip1h,
     otherModelsWind1h: s.otherModelsWind1h || null,
     xMap1h, xFrac1h, slotIdx1h,
+    isPortraitMode: false,
   };
 }
 
@@ -552,33 +554,37 @@ function clearCrosshairs() {
 function drawCrosshairs(fracX, idx1h, idx3h) {
   if (!lastRenderedData) return;
   const d = lastRenderedData;
-  const portrait = !!d.xFrac1h;
-  // Re-derive the same y-mappings used by the draw functions.
-  // In portrait all charts use the display series; in landscape curves use 1h data.
-  const temps_arr = portrait ? d.temps   : d.temps1h;
+  const portrait = !!d.isPortraitMode;
+  // drawTemp always uses temps1h; wind uses 3h display series in portrait, 1h in landscape.
+  const temps_arr = d.temps1h;
   const winds_arr = portrait ? d.winds   : d.winds1h;
   const gusts_arr = portrait ? d.gusts   : d.gusts1h;
   const ens_gust  = portrait ? d.ensGust : d.ensGust1h;
-  const idx       = portrait ? idx3h     : idx1h;
+  const wind_idx  = portrait ? idx3h     : idx1h;
   const TEMP_cssH = 130, TEMP_padT = 8, TEMP_padB = 8;
   const TEMP_ch   = TEMP_cssH - TEMP_padT - TEMP_padB;
-  let tmin = Math.floor(Math.min(...temps_arr) / 5) * 5;
-  let tmax = Math.ceil( Math.max(...temps_arr) / 5) * 5;
+  const validTemps = temps_arr.filter(v => v != null);
+  let tmin = Math.floor(Math.min(...validTemps) / 5) * 5;
+  let tmax = Math.ceil( Math.max(...validTemps) / 5) * 5;
   if (tmax - tmin < 15) { const mid = (tmin + tmax) / 2; tmin = Math.floor((mid - 7.5) / 5) * 5; tmax = tmin + 15; }
   const tRange   = tmax - tmin;
-  const tempDotY = TEMP_padT + (1 - (temps_arr[idx] - tmin) / tRange) * TEMP_ch;
+  const tempVal  = temps_arr[idx1h];
+  const tempDotY = tempVal != null ? TEMP_padT + (1 - (tempVal - tmin) / tRange) * TEMP_ch : null;
   const WIND_H = 130, WIND_KITE_H = 24, WIND_padT = WIND_KITE_H + 4;
   const WIND_chartH = WIND_H - WIND_padT;
   const safeGusts   = gusts_arr.map((g, i) => Math.max(g, winds_arr[i]));
   const ensGustMax  = ens_gust ? Math.max(...ens_gust.p90.filter(v => v != null)) : 0;
   const maxW        = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
-  const windDotY    = WIND_padT + (1 - winds_arr[idx] / maxW) * WIND_chartH;
+  const windDotY    = WIND_padT + (1 - winds_arr[wind_idx] / maxW) * WIND_chartH;
   const fracX3h = (idx3h + 0.5) / d.times.length;
   const fracX1h = (idx1h + 0.5) / d.times1h.length;
-  const DOT_Y   = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
-  const FRAC    = {
+  // Temp chart x: portrait uses xMap1h[idx1h] (variable-width slots), landscape uses fracX1h.
+  const tempX_frac = portrait && d.xMap1h ? null : fracX1h;
+  const tempX_abs  = portrait && d.xMap1h ? d.xMap1h[idx1h] : null;
+  const DOT_Y = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
+  const FRAC  = {
     'xh-top':  portrait ? fracX3h : (d.codes1h ? fracX1h : fracX3h),
-    'xh-temp': portrait ? fracX3h : fracX1h,
+    'xh-temp': tempX_frac,
     'xh-dir':  fracX3h,
     'xh-wind': portrait ? fracX3h : fracX1h,
   };
@@ -598,7 +604,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     ctx.clearRect(0, 0, c.width, c.height);
     ctx.save();
     ctx.scale(dpr, dpr);
-    const x = FRAC[id] * cssW;
+    const x = (id === 'xh-temp' && tempX_abs !== null) ? tempX_abs : (FRAC[id] * cssW);
     ctx.strokeStyle = 'rgba(255,255,255,0.7)';
     ctx.lineWidth   = 1;
     ctx.setLineDash([4, 3]);
@@ -606,7 +612,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     ctx.setLineDash([]);
     const dotY = DOT_Y[id];
     if (dotY !== null) {
-      const dotCol = (id === 'xh-temp') ? (temps_arr[idx] >= 0 ? '#cc2200' : '#4488ff') : '#fff';
+      const dotCol = (id === 'xh-temp') ? (tempVal >= 0 ? '#cc2200' : '#4488ff') : '#fff';
       ctx.fillStyle   = dotCol;
       ctx.strokeStyle = 'rgba(0,0,0,0.4)';
       ctx.lineWidth   = 1;
@@ -632,7 +638,7 @@ function showTooltip(idx1h, idx3h) {
   if (!lastRenderedData) return;
   const d = lastRenderedData;
   const tip = document.getElementById('hover-tooltip');
-  const portrait = !!d.xFrac1h;
+  const portrait = !!d.isPortraitMode;
   let timeStr, temp, prec, wind, gust, dir, code, tp10, tp90, wp10, wp90, gp10, gp90, pp10, pp90;
   if (portrait) {
     // Portrait: all values from display series (same zoom as icon row).
@@ -757,6 +763,7 @@ function hideTooltip() {
   document.getElementById('hover-tooltip').style.display = 'none';
   clearCrosshairs();
 }
+var _chartDragging = false;
 function attachHoverListeners() {
   document.getElementById('hover-tooltip').addEventListener('click', hideTooltip);
   const content = document.getElementById('forecast-content');
@@ -766,23 +773,34 @@ function attachHoverListeners() {
     const wrap = target && target.closest ? target.closest('.chart-canvas-wrap') : null;
     if (!wrap) { hideTooltip(); return; }
     const rect  = wrap.getBoundingClientRect();
-    // In portrait the wrap scrolls horizontally; add scrollLeft so relX is
-    // measured in canvas coordinates, not visible-viewport coordinates.
     const relX  = clientX - rect.left + (wrap.scrollLeft || 0);
     const span  = wrap.scrollWidth || rect.width;
     const fracX = Math.max(0, Math.min(1, relX / span));
     const n1h   = lastRenderedData.times1h.length;
     const n3h   = lastRenderedData.times.length;
-    const idx3h = Math.min(n3h - 1, Math.floor(fracX * n3h));
-    const idx1h = lastRenderedData.xFrac1h
-      ? idx3h
-      : Math.min(n1h - 1, Math.floor(fracX * n1h));
+    let idx1h, idx3h;
+    if (lastRenderedData.xMap1h) {
+      // Binary search on xMap1h (monotonically increasing) for the nearest 1h slot.
+      const xMap = lastRenderedData.xMap1h;
+      let lo = 0, hi = xMap.length - 1;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (xMap[mid] < relX) lo = mid + 1; else hi = mid;
+      }
+      idx1h = lo;
+      idx3h = lastRenderedData.slotIdx1h
+        ? Math.min(n3h - 1, lastRenderedData.slotIdx1h[idx1h])
+        : Math.min(n3h - 1, Math.floor(fracX * n3h));
+    } else {
+      idx3h = Math.min(n3h - 1, Math.floor(fracX * n3h));
+      idx1h = Math.min(n1h - 1, Math.floor(fracX * n1h));
+    }
     drawCrosshairs(fracX, idx1h, idx3h);
     showTooltip(idx1h, idx3h);
   }
 
   content.addEventListener('mousemove', e => {
-    if (!lastRenderedData) return;
+    if (_chartDragging || !lastRenderedData) return;
     const wrap = e.target.closest('.chart-canvas-wrap');
     if (!wrap) { hideTooltip(); return; }
     showTooltipAtX(e.clientX, e.target);
@@ -907,6 +925,56 @@ function initPortraitScrollSync() {
       velX = 0; horizontal = null;
     }, { passive: true });
   });
+
+  // Mouse drag: enables panning on desktop (no trackpad / scroll wheel needed).
+  let mouseDown = false, mouseLastX = 0, mouseLastT = 0, mouseVelX = 0;
+
+  function stopMouseDrag() {
+    if (!mouseDown) return;
+    mouseDown = false;
+    _chartDragging = false;
+    document.body.style.cursor = '';
+    if (Math.abs(mouseVelX) >= 0.5) {
+      (function step() {
+        mouseVelX *= DECEL;
+        if (Math.abs(mouseVelX) < 0.5) { rafId = null; return; }
+        syncAll(wraps[0].scrollLeft + mouseVelX);
+        rafId = requestAnimationFrame(step);
+      })();
+    }
+  }
+
+  wraps.forEach(wrap => {
+    wrap.addEventListener('mousedown', e => {
+      if (e.button !== 0) return;
+      if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+      mouseDown = true;
+      _chartDragging = true;
+      mouseVelX = 0;
+      mouseLastX = e.clientX;
+      mouseLastT = performance.now();
+      document.body.style.cursor = 'grabbing';
+      hideTooltip();
+      e.preventDefault();
+    });
+
+    wrap.addEventListener('mousemove', e => {
+      if (!mouseDown) return;
+      const cx  = e.clientX;
+      const dx  = cx - mouseLastX;
+      const now = performance.now();
+      const dt  = Math.max(1, now - mouseLastT);
+      mouseVelX = -(dx / dt) * 16;
+      syncAll(wraps[0].scrollLeft - dx);
+      mouseLastX = cx;
+      mouseLastT = now;
+    });
+
+    wrap.addEventListener('mouseup',    stopMouseDrag);
+    wrap.addEventListener('mouseleave', stopMouseDrag);
+  });
+
+  document.addEventListener('mouseup', stopMouseDrag);
 }
 initPortraitScrollSync();
 

--- a/app.js
+++ b/app.js
@@ -234,11 +234,11 @@ function computeXMap1h(times1h, displayTimes, portraitColW) {
 
 /**
  * Build a variable-resolution display series for portrait mode.
- * Base resolution decreases with distance from now; nighttime slots are
- * additionally coarsened by 3× (capped at 6h) so nights compress naturally:
+ * Resolution decreases with distance from now; nighttime is compressed:
  *   0–24 h  daytime  → 1h  |  nighttime → 3h
  *   24–48 h daytime  → 3h  |  nighttime → 6h
- *   48 h+            → 6h  (always, day or night)
+ *   48–168 h         → 6h  (always)
+ *   168 h+  daytime only, step increases linearly from 6h→12h (nighttime skipped)
  *
  * For coarse slots the icon/direction is picked from whichever hour in the
  * window is most "daytime" (prefers midday, avoids night).
@@ -263,10 +263,18 @@ function buildPortraitSeries(s) {
     const hoursAhead = (new Date(s.times1h[i]).getTime() - t0) / 3600000;
     const h = new Date(s.times1h[i]).getHours();
     const night = typeof isNight === 'function' ? isNight(s.times1h[i]) : (h < 6 || h >= 20);
-    const baseStep = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : hoursAhead < 168 ? 6 : 12;
-    const step = hoursAhead < 168
-      ? Math.min(6,  night ? baseStep * 3 : baseStep)
-      : Math.min(24, night ? baseStep * 2 : baseStep);
+
+    let step;
+    if (hoursAhead >= 168) {
+      // Extended zone: skip nighttime icons entirely (req #4)
+      if (night) { i += 1; continue; }
+      // Linear zoom: step increases from 6h at day 7 to 12h at day 16
+      const ratio = Math.min(1, (hoursAhead - 168) / 216);
+      step = Math.ceil((6 + 6 * ratio) / 3) * 3; // snaps to 6, 9, or 12
+    } else {
+      const baseStep = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : 6;
+      step = Math.min(6, night ? baseStep * 3 : baseStep);
+    }
 
     // For coarse steps pick the slot in [i, i+step) that is most daytime.
     let best = i;
@@ -340,14 +348,97 @@ function buildPortraitSeries(s) {
   };
 }
 
+/**
+ * Build a display series for landscape mode.
+ * Days 1–7: uniform 3h slots so exactly 7 days fills the viewport at baseColW.
+ * Days 7–16: daytime only (nighttime skipped); step increases linearly from
+ *             6h at day 7 to 12h at day 16 (linear zoom, req #3/#4).
+ * colW is the base column width (= viewportWidth / 56) so days 1–7 fill the
+ * screen and days 8–16 extend beyond, accessible by scrolling.
+ */
+function buildLandscapeSeries(s, colW) {
+  const t0 = new Date(s.times1h[0]).getTime();
+  const times = [], codes = [], dirs = [];
+  const precips = [], winds = [], temps = [], gusts = [];
+  const hasEns = s.ensTemp1h != null;
+  const ensTemp = { p10: [], p50: [], p90: [] };
+  const ensWind = { p10: [], p50: [], p90: [] };
+  const ensGust = { p10: [], p50: [], p90: [] };
+  const ensPrecip = { p10: [], p50: [], p90: [] };
+
+  let i = 0;
+  while (i < s.times1h.length) {
+    const hoursAhead = (new Date(s.times1h[i]).getTime() - t0) / 3600000;
+    const h = new Date(s.times1h[i]).getHours();
+    const night = typeof isNight === 'function' ? isNight(s.times1h[i]) : (h < 6 || h >= 20);
+
+    let step;
+    if (hoursAhead < 168) {
+      step = STEP; // 3h uniform — first 7 days fill viewport exactly
+    } else {
+      // Extended zone: skip nighttime icons (req #4)
+      if (night) { i += 1; continue; }
+      // Linear zoom: step increases from 6h at day 7 to 12h at day 16
+      const ratio = Math.min(1, (hoursAhead - 168) / 216);
+      step = Math.ceil((6 + 6 * ratio) / 3) * 3; // snaps to 6, 9, or 12
+    }
+
+    // For coarse steps pick the slot in [i, i+step) that is most daytime.
+    let best = i;
+    if (step > 1) {
+      let bestScore = -Infinity;
+      const end = Math.min(i + step, s.times1h.length);
+      for (let j = i; j < end; j++) {
+        const hj = new Date(s.times1h[j]).getHours();
+        const nj = typeof isNight === 'function' ? isNight(s.times1h[j]) : (hj < 6 || hj >= 20);
+        const score = (nj ? 0 : 100) - Math.abs(hj - 12);
+        if (score > bestScore) { bestScore = score; best = j; }
+      }
+    }
+
+    times.push(s.times1h[i]);
+    codes.push(s.codes1h ? s.codes1h[best] : null);
+    dirs.push(s.dirs1h ? s.dirs1h[best]
+                       : s.dirs[Math.min(Math.round(best / 3), s.dirs.length - 1)]);
+    precips.push(s.precips1h[best]);
+    winds.push(s.winds1h[best]);
+    temps.push(s.temps1h[best]);
+    gusts.push(s.gusts1h[best]);
+    if (hasEns) {
+      ['p10', 'p50', 'p90'].forEach(k => {
+        ensTemp[k].push(s.ensTemp1h[k][best]);
+        ensWind[k].push(s.ensWind1h[k][best]);
+        ensGust[k].push(s.ensGust1h[k][best]);
+        ensPrecip[k].push(s.ensPrecip1h[k][best]);
+      });
+    }
+
+    i += step;
+  }
+
+  const { xMap1h, xFrac1h, slotIdx1h } = computeXMap1h(s.times1h, times, colW);
+
+  return {
+    times, codes, dirs, temps, precips, gusts, winds,
+    ensTemp:   hasEns ? ensTemp   : null,
+    ensWind:   hasEns ? ensWind   : null,
+    ensGust:   hasEns ? ensGust   : null,
+    ensPrecip: hasEns ? ensPrecip : null,
+    times1h:     s.times1h,   temps1h:   s.temps1h,
+    precips1h:   s.precips1h, gusts1h:   s.gusts1h,
+    winds1h:     s.winds1h,   codes1h:   s.codes1h,
+    dirs1h:      s.dirs1h,
+    ensTemp1h:   s.ensTemp1h, ensWind1h:  s.ensWind1h,
+    ensGust1h:   s.ensGust1h, ensPrecip1h: s.ensPrecip1h,
+    otherModelsWind1h: s.otherModelsWind1h || null,
+    xMap1h, xFrac1h, slotIdx1h,
+  };
+}
+
 function renderDisplay(d, scrollToNow = false) {
   const portrait       = window.matchMedia('(orientation: portrait)').matches;
   const invertedColors = window.matchMedia('(inverted-colors: inverted)').matches;
   syncInvertedColorsClass();
-  // Portrait always scrolls at variable resolution. Landscape also scrolls when
-  // FORECAST_DAYS > 7 so the extended range is reachable rather than squashed.
-  const scrollable = portrait || FORECAST_DAYS > 7;
-  document.body.classList.toggle('forecast-extended', FORECAST_DAYS > 7);
   const n3h = Math.ceil(FORECAST_DAYS * 24 / STEP);
   const n1h = Math.ceil(FORECAST_DAYS * 24 / STEP1H);
   const s = {
@@ -368,12 +459,24 @@ function renderDisplay(d, scrollToNow = false) {
       ? d.otherModelsWind1h.map(m => ({ model: m.model, winds1h: m.winds1h.slice(0, n1h) }))
       : null,
   };
-  const colW = scrollable ? PORTRAIT_COL_W : null;
-  const displayData = scrollable ? buildPortraitSeries(s) : s;
+
+  let colW, displayData;
+  if (portrait) {
+    colW = PORTRAIT_COL_W;
+    displayData = buildPortraitSeries(s);
+  } else {
+    // Landscape: 7 days fills the viewport; days 8–16 are accessible by scrolling.
+    // Compute colW from the canvas wrap width (excludes y-axis columns).
+    const wrap = document.querySelector ? document.querySelector('.chart-canvas-wrap') : null;
+    const viewW = (wrap && wrap.clientWidth > 0) ? wrap.clientWidth : (window.innerWidth || 800);
+    colW = viewW / (7 * 24 / STEP);
+    displayData = buildLandscapeSeries(s, colW);
+  }
+
   renderAll(displayData, invertedColors, colW);
   lastRenderedData = displayData;
-  // Scroll to center the current time in the viewport on initial load.
-  if (scrollable && scrollToNow && displayData.xMap1h) {
+  // Portrait: scroll to center the current time in the viewport on initial load.
+  if (portrait && scrollToNow && displayData.xMap1h) {
     requestAnimationFrame(() => {
       const nowMs = Date.now();
       const idx = displayData.times1h.findIndex(t => new Date(t).getTime() >= nowMs);
@@ -1712,20 +1815,6 @@ document.getElementById('model-select').addEventListener('change', () => {
             || localStorage.getItem('vejr_city') || '';
   if (city) loadAndSync(city, getModel());
 });
-(function initForecastRangeBtn() {
-  const btn = document.getElementById('forecast-range-btn');
-  btn.textContent = FORECAST_DAYS + 'd';
-  btn.classList.toggle('active', FORECAST_DAYS > 7);
-  btn.addEventListener('click', () => {
-    const next = FORECAST_DAYS === 7 ? FORECAST_DAYS_EXTENDED : 7;
-    setForecastDays(next);
-    btn.textContent = next + 'd';
-    btn.classList.toggle('active', next > 7);
-    const city = document.getElementById('city-input').value.trim()
-              || localStorage.getItem('vejr_city') || '';
-    if (city) load(city, getModel());
-  });
-})();
 let resizeTimer;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);

--- a/app.js
+++ b/app.js
@@ -263,8 +263,10 @@ function buildPortraitSeries(s) {
     const hoursAhead = (new Date(s.times1h[i]).getTime() - t0) / 3600000;
     const h = new Date(s.times1h[i]).getHours();
     const night = typeof isNight === 'function' ? isNight(s.times1h[i]) : (h < 6 || h >= 20);
-    const baseStep = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : 6;
-    const step = Math.min(6, night ? baseStep * 3 : baseStep);
+    const baseStep = hoursAhead < 24 ? 1 : hoursAhead < 48 ? 3 : hoursAhead < 168 ? 6 : 12;
+    const step = hoursAhead < 168
+      ? Math.min(6,  night ? baseStep * 3 : baseStep)
+      : Math.min(24, night ? baseStep * 2 : baseStep);
 
     // For coarse steps pick the slot in [i, i+step) that is most daytime.
     let best = i;
@@ -342,9 +344,10 @@ function renderDisplay(d, scrollToNow = false) {
   const portrait       = window.matchMedia('(orientation: portrait)').matches;
   const invertedColors = window.matchMedia('(inverted-colors: inverted)').matches;
   syncInvertedColorsClass();
-  // In portrait, show the full forecast from the data start (today midnight) so
-  // the user can scroll back to see today's earlier hours. In landscape show the
-  // full 7-day window from data start.
+  // Portrait always scrolls at variable resolution. Landscape also scrolls when
+  // FORECAST_DAYS > 7 so the extended range is reachable rather than squashed.
+  const scrollable = portrait || FORECAST_DAYS > 7;
+  document.body.classList.toggle('forecast-extended', FORECAST_DAYS > 7);
   const n3h = Math.ceil(FORECAST_DAYS * 24 / STEP);
   const n1h = Math.ceil(FORECAST_DAYS * 24 / STEP1H);
   const s = {
@@ -365,12 +368,12 @@ function renderDisplay(d, scrollToNow = false) {
       ? d.otherModelsWind1h.map(m => ({ model: m.model, winds1h: m.winds1h.slice(0, n1h) }))
       : null,
   };
-  const colW = portrait ? PORTRAIT_COL_W : null;
-  const displayData = portrait ? buildPortraitSeries(s) : s;
+  const colW = scrollable ? PORTRAIT_COL_W : null;
+  const displayData = scrollable ? buildPortraitSeries(s) : s;
   renderAll(displayData, invertedColors, colW);
   lastRenderedData = displayData;
-  // In portrait, scroll to center the current time in the viewport on initial load.
-  if (portrait && scrollToNow && displayData.xMap1h) {
+  // Scroll to center the current time in the viewport on initial load.
+  if (scrollable && scrollToNow && displayData.xMap1h) {
     requestAnimationFrame(() => {
       const nowMs = Date.now();
       const idx = displayData.times1h.findIndex(t => new Date(t).getTime() >= nowMs);
@@ -1709,6 +1712,20 @@ document.getElementById('model-select').addEventListener('change', () => {
             || localStorage.getItem('vejr_city') || '';
   if (city) loadAndSync(city, getModel());
 });
+(function initForecastRangeBtn() {
+  const btn = document.getElementById('forecast-range-btn');
+  btn.textContent = FORECAST_DAYS + 'd';
+  btn.classList.toggle('active', FORECAST_DAYS > 7);
+  btn.addEventListener('click', () => {
+    const next = FORECAST_DAYS === 7 ? FORECAST_DAYS_EXTENDED : 7;
+    setForecastDays(next);
+    btn.textContent = next + 'd';
+    btn.classList.toggle('active', next > 7);
+    const city = document.getElementById('city-input').value.trim()
+              || localStorage.getItem('vejr_city') || '';
+    if (city) load(city, getModel());
+  });
+})();
 let resizeTimer;
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);

--- a/app.js
+++ b/app.js
@@ -554,40 +554,29 @@ function clearCrosshairs() {
 function drawCrosshairs(fracX, idx1h, idx3h) {
   if (!lastRenderedData) return;
   const d = lastRenderedData;
-  const portrait = !!d.isPortraitMode;
-  // drawTemp always uses temps1h; wind uses 3h display series in portrait, 1h in landscape.
-  const temps_arr = d.temps1h;
-  const winds_arr = portrait ? d.winds   : d.winds1h;
-  const gusts_arr = portrait ? d.gusts   : d.gusts1h;
-  const ens_gust  = portrait ? d.ensGust : d.ensGust1h;
-  const wind_idx  = portrait ? idx3h     : idx1h;
+  // renderAll always fires the portrait branch (colW is always non-null), so:
+  //   drawTemp  uses d.temps1h + d.xMap1h  → temp dot tracks xMap1h[idx1h]
+  //   drawWind  uses d.winds/d.gusts (3h)  → wind dot tracks fracX3h
   const TEMP_cssH = 130, TEMP_padT = 8, TEMP_padB = 8;
   const TEMP_ch   = TEMP_cssH - TEMP_padT - TEMP_padB;
-  const validTemps = temps_arr.filter(v => v != null);
+  const validTemps = d.temps1h.filter(v => v != null);
   let tmin = Math.floor(Math.min(...validTemps) / 5) * 5;
   let tmax = Math.ceil( Math.max(...validTemps) / 5) * 5;
   if (tmax - tmin < 15) { const mid = (tmin + tmax) / 2; tmin = Math.floor((mid - 7.5) / 5) * 5; tmax = tmin + 15; }
-  const tRange   = tmax - tmin;
-  const tempVal  = temps_arr[idx1h];
+  const tRange  = tmax - tmin;
+  const tempVal = d.temps1h[idx1h];
   const tempDotY = tempVal != null ? TEMP_padT + (1 - (tempVal - tmin) / tRange) * TEMP_ch : null;
   const WIND_H = 130, WIND_KITE_H = 24, WIND_padT = WIND_KITE_H + 4;
   const WIND_chartH = WIND_H - WIND_padT;
-  const safeGusts   = gusts_arr.map((g, i) => Math.max(g, winds_arr[i]));
-  const ensGustMax  = ens_gust ? Math.max(...ens_gust.p90.filter(v => v != null)) : 0;
-  const maxW        = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
-  const windDotY    = WIND_padT + (1 - winds_arr[wind_idx] / maxW) * WIND_chartH;
-  const fracX3h = (idx3h + 0.5) / d.times.length;
-  const fracX1h = (idx1h + 0.5) / d.times1h.length;
-  // Temp chart x: portrait uses xMap1h[idx1h] (variable-width slots), landscape uses fracX1h.
-  const tempX_frac = portrait && d.xMap1h ? null : fracX1h;
-  const tempX_abs  = portrait && d.xMap1h ? d.xMap1h[idx1h] : null;
+  const safeGusts  = d.gusts.map((g, i) => Math.max(g, d.winds[i]));
+  const ensGustMax = d.ensGust ? Math.max(...d.ensGust.p90.filter(v => v != null)) : 0;
+  const maxW       = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
+  const windDotY   = WIND_padT + (1 - d.winds[idx3h] / maxW) * WIND_chartH;
+  const fracX3h    = (idx3h + 0.5) / d.times.length;
+  // xMap1h[idx1h] is the CSS x-centre of the 1h point as drawn by drawTemp.
+  const tempXabs   = d.xMap1h ? d.xMap1h[idx1h] : fracX3h;
   const DOT_Y = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
-  const FRAC  = {
-    'xh-top':  portrait ? fracX3h : (d.codes1h ? fracX1h : fracX3h),
-    'xh-temp': tempX_frac,
-    'xh-dir':  fracX3h,
-    'xh-wind': portrait ? fracX3h : fracX1h,
-  };
+  const FRAC  = { 'xh-top': fracX3h, 'xh-temp': null, 'xh-dir': fracX3h, 'xh-wind': fracX3h };
   XH_CANVASES.forEach(id => {
     const c   = document.getElementById(id);
     const ref = document.getElementById(XH_PAIR[id]);
@@ -604,7 +593,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     ctx.clearRect(0, 0, c.width, c.height);
     ctx.save();
     ctx.scale(dpr, dpr);
-    const x = (id === 'xh-temp' && tempX_abs !== null) ? tempX_abs : (FRAC[id] * cssW);
+    const x = (id === 'xh-temp') ? tempXabs : (FRAC[id] * cssW);
     ctx.strokeStyle = 'rgba(255,255,255,0.7)';
     ctx.lineWidth   = 1;
     ctx.setLineDash([4, 3]);
@@ -926,14 +915,28 @@ function initPortraitScrollSync() {
     }, { passive: true });
   });
 
-  // Mouse drag: enables panning on desktop (no trackpad / scroll wheel needed).
+  // Mouse drag: enables panning on desktop. Listeners are on document so the
+  // drag continues even when the mouse leaves the wrap element.
   let mouseDown = false, mouseLastX = 0, mouseLastT = 0, mouseVelX = 0;
+
+  function onDocMouseMove(e) {
+    const cx  = e.clientX;
+    const dx  = cx - mouseLastX;
+    const now = performance.now();
+    const dt  = Math.max(1, now - mouseLastT);
+    mouseVelX = -(dx / dt) * 16;
+    syncAll(wraps[0].scrollLeft - dx);
+    mouseLastX = cx;
+    mouseLastT = now;
+  }
 
   function stopMouseDrag() {
     if (!mouseDown) return;
     mouseDown = false;
     _chartDragging = false;
     document.body.style.cursor = '';
+    document.removeEventListener('mousemove', onDocMouseMove);
+    document.removeEventListener('mouseup',   stopMouseDrag);
     if (Math.abs(mouseVelX) >= 0.5) {
       (function step() {
         mouseVelX *= DECEL;
@@ -955,26 +958,11 @@ function initPortraitScrollSync() {
       mouseLastT = performance.now();
       document.body.style.cursor = 'grabbing';
       hideTooltip();
+      document.addEventListener('mousemove', onDocMouseMove);
+      document.addEventListener('mouseup',   stopMouseDrag);
       e.preventDefault();
     });
-
-    wrap.addEventListener('mousemove', e => {
-      if (!mouseDown) return;
-      const cx  = e.clientX;
-      const dx  = cx - mouseLastX;
-      const now = performance.now();
-      const dt  = Math.max(1, now - mouseLastT);
-      mouseVelX = -(dx / dt) * 16;
-      syncAll(wraps[0].scrollLeft - dx);
-      mouseLastX = cx;
-      mouseLastT = now;
-    });
-
-    wrap.addEventListener('mouseup',    stopMouseDrag);
-    wrap.addEventListener('mouseleave', stopMouseDrag);
   });
-
-  document.addEventListener('mouseup', stopMouseDrag);
 }
 initPortraitScrollSync();
 

--- a/app.js
+++ b/app.js
@@ -462,38 +462,6 @@ function renderDisplay(d, scrollToNow = false) {
       : null,
   };
 
-  // Trim trailing null temperatures so the API's incomplete last day doesn't
-  // show as a drop to zero (null coerces to 0 in JS arithmetic).
-  let clipEnd1h = s.times1h.length;
-  while (clipEnd1h > 0 && s.temps1h[clipEnd1h - 1] == null) clipEnd1h--;
-  if (clipEnd1h < s.times1h.length) {
-    const clipMs = new Date(s.times1h[clipEnd1h - 1]).getTime();
-    s.times1h    = s.times1h.slice(0, clipEnd1h);
-    s.temps1h    = s.temps1h.slice(0, clipEnd1h);
-    s.precips1h  = s.precips1h.slice(0, clipEnd1h);
-    s.gusts1h    = s.gusts1h.slice(0, clipEnd1h);
-    s.winds1h    = s.winds1h.slice(0, clipEnd1h);
-    s.codes1h    = s.codes1h  ? s.codes1h.slice(0, clipEnd1h)  : null;
-    s.dirs1h     = s.dirs1h   ? s.dirs1h.slice(0, clipEnd1h)   : null;
-    if (s.ensTemp1h)   s.ensTemp1h   = slicePercentilesFrom(s.ensTemp1h,   0, clipEnd1h);
-    if (s.ensWind1h)   s.ensWind1h   = slicePercentilesFrom(s.ensWind1h,   0, clipEnd1h);
-    if (s.ensGust1h)   s.ensGust1h   = slicePercentilesFrom(s.ensGust1h,   0, clipEnd1h);
-    if (s.ensPrecip1h) s.ensPrecip1h = slicePercentilesFrom(s.ensPrecip1h, 0, clipEnd1h);
-    let clipEnd3h = s.times.length;
-    while (clipEnd3h > 0 && new Date(s.times[clipEnd3h - 1]).getTime() > clipMs) clipEnd3h--;
-    s.times   = s.times.slice(0, clipEnd3h);
-    s.temps   = s.temps.slice(0, clipEnd3h);
-    s.precips = s.precips.slice(0, clipEnd3h);
-    s.gusts   = s.gusts.slice(0, clipEnd3h);
-    s.winds   = s.winds.slice(0, clipEnd3h);
-    s.dirs    = s.dirs.slice(0, clipEnd3h);
-    s.codes   = s.codes.slice(0, clipEnd3h);
-    if (s.ensTemp)   s.ensTemp   = slicePercentilesFrom(s.ensTemp,   0, clipEnd3h);
-    if (s.ensWind)   s.ensWind   = slicePercentilesFrom(s.ensWind,   0, clipEnd3h);
-    if (s.ensGust)   s.ensGust   = slicePercentilesFrom(s.ensGust,   0, clipEnd3h);
-    if (s.ensPrecip) s.ensPrecip = slicePercentilesFrom(s.ensPrecip, 0, clipEnd3h);
-  }
-
   let colW, displayData;
   if (portrait) {
     colW = PORTRAIT_COL_W;

--- a/app.js
+++ b/app.js
@@ -460,6 +460,38 @@ function renderDisplay(d, scrollToNow = false) {
       : null,
   };
 
+  // Trim trailing null temperatures so the API's incomplete last day doesn't
+  // show as a drop to zero (null coerces to 0 in JS arithmetic).
+  let clipEnd1h = s.times1h.length;
+  while (clipEnd1h > 0 && s.temps1h[clipEnd1h - 1] == null) clipEnd1h--;
+  if (clipEnd1h < s.times1h.length) {
+    const clipMs = new Date(s.times1h[clipEnd1h - 1]).getTime();
+    s.times1h    = s.times1h.slice(0, clipEnd1h);
+    s.temps1h    = s.temps1h.slice(0, clipEnd1h);
+    s.precips1h  = s.precips1h.slice(0, clipEnd1h);
+    s.gusts1h    = s.gusts1h.slice(0, clipEnd1h);
+    s.winds1h    = s.winds1h.slice(0, clipEnd1h);
+    s.codes1h    = s.codes1h  ? s.codes1h.slice(0, clipEnd1h)  : null;
+    s.dirs1h     = s.dirs1h   ? s.dirs1h.slice(0, clipEnd1h)   : null;
+    if (s.ensTemp1h)   s.ensTemp1h   = slicePercentilesFrom(s.ensTemp1h,   0, clipEnd1h);
+    if (s.ensWind1h)   s.ensWind1h   = slicePercentilesFrom(s.ensWind1h,   0, clipEnd1h);
+    if (s.ensGust1h)   s.ensGust1h   = slicePercentilesFrom(s.ensGust1h,   0, clipEnd1h);
+    if (s.ensPrecip1h) s.ensPrecip1h = slicePercentilesFrom(s.ensPrecip1h, 0, clipEnd1h);
+    let clipEnd3h = s.times.length;
+    while (clipEnd3h > 0 && new Date(s.times[clipEnd3h - 1]).getTime() > clipMs) clipEnd3h--;
+    s.times   = s.times.slice(0, clipEnd3h);
+    s.temps   = s.temps.slice(0, clipEnd3h);
+    s.precips = s.precips.slice(0, clipEnd3h);
+    s.gusts   = s.gusts.slice(0, clipEnd3h);
+    s.winds   = s.winds.slice(0, clipEnd3h);
+    s.dirs    = s.dirs.slice(0, clipEnd3h);
+    s.codes   = s.codes.slice(0, clipEnd3h);
+    if (s.ensTemp)   s.ensTemp   = slicePercentilesFrom(s.ensTemp,   0, clipEnd3h);
+    if (s.ensWind)   s.ensWind   = slicePercentilesFrom(s.ensWind,   0, clipEnd3h);
+    if (s.ensGust)   s.ensGust   = slicePercentilesFrom(s.ensGust,   0, clipEnd3h);
+    if (s.ensPrecip) s.ensPrecip = slicePercentilesFrom(s.ensPrecip, 0, clipEnd3h);
+  }
+
   let colW, displayData;
   if (portrait) {
     colW = PORTRAIT_COL_W;

--- a/app.js
+++ b/app.js
@@ -475,15 +475,16 @@ function renderDisplay(d, scrollToNow = false) {
 
   renderAll(displayData, invertedColors, colW);
   lastRenderedData = displayData;
-  // Portrait: scroll to center the current time in the viewport on initial load.
-  if (portrait && scrollToNow && displayData.xMap1h) {
+  // Scroll to current time on initial load.
+  // Portrait: center "now" in the viewport. Landscape: left-align at "now" so 7 days ahead fills the screen.
+  if (scrollToNow && displayData.xMap1h) {
     requestAnimationFrame(() => {
       const nowMs = Date.now();
       const idx = displayData.times1h.findIndex(t => new Date(t).getTime() >= nowMs);
       const xNow = idx >= 0 ? displayData.xMap1h[idx] : displayData.xMap1h[displayData.xMap1h.length - 1];
       const wraps = document.querySelectorAll ? document.querySelectorAll('.chart-canvas-wrap') : [];
       const visW = wraps[0] ? wraps[0].clientWidth : 0;
-      const target = Math.max(0, xNow - visW / 2);
+      const target = portrait ? Math.max(0, xNow - visW / 2) : Math.max(0, xNow);
       wraps.forEach(w => { w.scrollLeft = target; });
     });
   }
@@ -1706,6 +1707,7 @@ async function loadAtCoords(lat, lon, model) {
     document.getElementById('loading').style.display = 'none';
     forecastEl.style.display = 'block';
     forecastEl.classList.remove('updating');
+    const isFirstLoad = !isReload;
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
       ensTemp, ensWind, ensGust, ensPrecip,
@@ -1714,7 +1716,7 @@ async function loadAtCoords(lat, lon, model) {
       otherModelsWind1h: null,
     };
     requestAnimationFrame(() => requestAnimationFrame(() => {
-      renderDisplay(lastData);
+      renderDisplay(lastData, isFirstLoad);
       // Background fetch of other-model wind lines; re-render on arrival.
       const capturedData = lastData;
       fetchOtherModelsWind(lat, lon, model)

--- a/charts.js
+++ b/charts.js
@@ -275,22 +275,19 @@ function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h,
 
   for (let i = 0; i < temps.length - 1; i++) {
     const t0 = temps[i], t1 = temps[i+1];
+    if (t0 == null || t1 == null) continue;
     const x0 = cx2(i),   x1 = cx2(i+1);
     const py0 = ty(t0),  py1 = ty(t1);
 
     if ((t0 >= 0 && t1 >= 0) || (t0 < 0 && t1 < 0)) {
-      // no crossing — single colour
       ctx.strokeStyle = t0 >= 0 ? TEMP_ABOVE : TEMP_BELOW;
       ctx.beginPath(); ctx.moveTo(x0, py0); ctx.lineTo(x1, py1); ctx.stroke();
     } else {
       // zero crossing — split at the interpolated x,y
-      const frac = t0 / (t0 - t1);           // fraction along segment where temp=0
+      const frac = t0 / (t0 - t1);
       const xMid = x0 + frac * (x1 - x0);
-
-      // first half
       ctx.strokeStyle = t0 >= 0 ? TEMP_ABOVE : TEMP_BELOW;
       ctx.beginPath(); ctx.moveTo(x0, py0); ctx.lineTo(xMid, y0); ctx.stroke();
-      // second half
       ctx.strokeStyle = t1 >= 0 ? TEMP_ABOVE : TEMP_BELOW;
       ctx.beginPath(); ctx.moveTo(xMid, y0); ctx.lineTo(x1, py1); ctx.stroke();
     }
@@ -611,7 +608,12 @@ function _drawWindLine(ctx, values, cx2, wy, strokeStyle, lineWidth) {
   ctx.lineWidth   = lineWidth;
   ctx.setLineDash([]);
   ctx.beginPath();
-  values.forEach((v, i) => i === 0 ? ctx.moveTo(cx2(i), wy(v)) : ctx.lineTo(cx2(i), wy(v)));
+  let started = false;
+  values.forEach((v, i) => {
+    if (v == null) { started = false; return; }
+    if (!started) { ctx.moveTo(cx2(i), wy(v)); started = true; }
+    else ctx.lineTo(cx2(i), wy(v));
+  });
   ctx.stroke();
 }
 
@@ -763,14 +765,17 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
 
 
   // --- wind fill (colour-mapped gradient below wind line) ---
-  if (n > 1) {
+  // Only fill up to the last non-null wind value; null entries (unavailable
+  // model data) are left blank rather than drawn as flat zero.
+  const lastNonNull = (() => { for (let i = n - 1; i >= 0; i--) if (winds[i] != null) return i; return -1; })();
+  if (n > 1 && lastNonNull > 0) {
     const grad = ctx.createLinearGradient(0, 0, cssW, 0);
-    winds.forEach((v, i) => grad.addColorStop(cx2(i) / cssW, windColorStr(v, 0.72)));
+    winds.forEach((v, i) => { if (v != null) grad.addColorStop(cx2(i) / cssW, windColorStr(v, 0.72)); });
     ctx.fillStyle = grad;
     ctx.beginPath();
-    ctx.moveTo(cx2(0), wy(winds[0]));
-    for (let i = 1; i < n; i++) ctx.lineTo(cx2(i), wy(winds[i]));
-    ctx.lineTo(cx2(n - 1), base);
+    ctx.moveTo(cx2(0), wy(winds[0] ?? 0));
+    for (let i = 1; i <= lastNonNull; i++) ctx.lineTo(cx2(i), wy(winds[i] ?? winds[i - 1] ?? 0));
+    ctx.lineTo(cx2(lastNonNull), base);
     ctx.lineTo(cx2(0), base);
     ctx.closePath();
     ctx.fill();

--- a/charts.js
+++ b/charts.js
@@ -83,7 +83,7 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
     const midX = ((segs[s]+segs[s+1])/2) * colW;
     const segDate = new Date(times[segs[s]]);
     const isExtended = segDate.getTime() >= extThreshMs;
-    const name = isExtended ? String(segDate.getDate()) : DA_DAYS[segDate.getDay()];
+    const name = isExtended ? DA_DAYS3[segDate.getDay()] : DA_DAYS[segDate.getDay()];
     dayLabels.push({ midX, halfW: ctx.measureText(name).width / 2 });
     ctx.fillStyle = isExtended ? (invertedColors ? '#7a8a9a' : '#778899') : textDay;
     ctx.textAlign = 'center';

--- a/charts.js
+++ b/charts.js
@@ -70,28 +70,34 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
   ctx.lineWidth = 0.5;
   ctx.beginPath(); ctx.moveTo(0,TIME_H); ctx.lineTo(cssW,TIME_H); ctx.stroke();
 
+  // 7-day threshold: slots beyond this get day-of-month labels and no dividers
+  const extThreshMs = times.length > 0
+    ? new Date(times[0]).getTime() + 7 * 24 * 3600 * 1000
+    : Infinity;
+
   // day segments & names
   const segs = [0,...divs,n];
   ctx.font = `700 11px 'IBM Plex Sans', sans-serif`;
   const dayLabels = [];
   for(let s=0;s<segs.length-1;s++){
     const midX = ((segs[s]+segs[s+1])/2) * colW;
-    const name = DA_DAYS[new Date(times[segs[s]]).getDay()];
+    const segDate = new Date(times[segs[s]]);
+    const isExtended = segDate.getTime() >= extThreshMs;
+    const name = isExtended ? String(segDate.getDate()) : DA_DAYS[segDate.getDay()];
     dayLabels.push({ midX, halfW: ctx.measureText(name).width / 2 });
-    ctx.fillStyle = textDay;
+    ctx.fillStyle = isExtended ? (invertedColors ? '#7a8a9a' : '#778899') : textDay;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(name, midX, TIME_H/2);
   }
 
-  // Hour tick marks: every 3h for 1h-resolution data, every 6h for 3h-resolution data.
-  // With PORTRAIT_COL_W = 24 px per slot: 3h ticks are 72 px apart (1h data),
-  // or 6h ticks are 48 px apart (3h data) — both comfortable.
+  // Hour tick marks (suppressed in extended zone where coarse slots make them misleading)
   const stepHours = times.length >= 2
     ? (new Date(times[1]).getTime() - new Date(times[0]).getTime()) / 3600000
     : 3;
   const tickEvery = stepHours <= 1 ? 3 : 6;
   times.forEach((t,i)=>{
+    if (new Date(t).getTime() >= extThreshMs) return; // no ticks in extended zone
     const h = new Date(t).getHours();
     if(h===0||h%tickEvery!==0) return;
     const x = (i+0.5)*colW;
@@ -103,9 +109,10 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
     ctx.fillText(h, x, TIME_H/2);
   });
 
-  /* ---- day dividers through time axis ---- */
+  /* ---- day dividers through time axis (first 7 days only) ---- */
   ctx.strokeStyle = divCol; ctx.lineWidth = 1;
   divs.forEach(i=>{
+    if (new Date(times[i]).getTime() >= extThreshMs) return;
     const x = i*colW;
     ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,TIME_H); ctx.stroke();
   });
@@ -115,8 +122,9 @@ function drawTopRow(times, codes, precips, invertedColors, totalCssW = null) {
   ctx.fillStyle = iconBg;
   ctx.fillRect(0, iconY, cssW, ICON_H);
 
-  // day dividers
+  // day dividers (first 7 days only)
   divs.forEach(i=>{
+    if (new Date(times[i]).getTime() >= extThreshMs) return;
     const x = i*colW;
     ctx.strokeStyle=divCol; ctx.lineWidth=1;
     ctx.beginPath(); ctx.moveTo(x,iconY); ctx.lineTo(x,iconY+ICON_H); ctx.stroke();
@@ -443,13 +451,17 @@ function drawWindDir(times, winds, dirs, totalCssW = null) {
   wrap.parentElement.style.height = DIR_H + 'px';
 
   const divs  = dayDivs(times);
+  const extThreshMsDir = times.length > 0
+    ? new Date(times[0]).getTime() + 7 * 24 * 3600 * 1000
+    : Infinity;
 
   // dark background
   ctx.fillStyle = '#1e2a38';
   ctx.fillRect(0, 0, cssW, DIR_H);
 
-  // day dividers
+  // day dividers (first 7 days only — req #3)
   divs.forEach(i => {
+    if (new Date(times[i]).getTime() >= extThreshMsDir) return;
     const x = i * colW;
     ctx.strokeStyle = 'rgba(255,255,255,0.18)'; ctx.lineWidth = 1;
     ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, DIR_H); ctx.stroke();
@@ -695,6 +707,9 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   const ctx    = resolveDPI(canvas, cssW, WIND_H);
   ctx.clearRect(0, 0, cssW, WIND_H);
   const divs = dayDivs(times);
+  const extThreshMsWind = times.length > 0
+    ? new Date(times[0]).getTime() + 7 * 24 * 3600 * 1000
+    : Infinity;
   const cx2  = xMap ? (i => xMap[i]) : (i => (i + 0.5) * colW);
 
   // 3hr kite data (dirs align with times3h)
@@ -731,9 +746,10 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
     });
   }
 
-  // --- grid & day dividers ---
+  // --- grid & day dividers (first 7 days only — req #3) ---
   _drawWindGrid(ctx, wLevels, wy, cssW);
   divs.forEach(i => {
+    if (new Date(times[i]).getTime() >= extThreshMsWind) return;
     const x = xMap ? (xMap[i - 1] + xMap[i]) / 2 : i * colW;
     ctx.strokeStyle = '#667788'; ctx.lineWidth = 1;
     ctx.beginPath(); ctx.moveTo(x, cY); ctx.lineTo(x, cY + WIND_H); ctx.stroke();
@@ -876,7 +892,12 @@ function renderAll(d, invertedColors, portraitColW = null) {
   const totalCssW = portrait ? d.times.length * portraitColW : null;
   // Pre-compute day-divider pixel positions from the display series so every
   // chart row (icon row, temp, wind) places its divider at exactly the same x.
-  const divXs = portrait ? dayDivs(d.times).map(i => i * portraitColW) : null;
+  const extThreshMsAll = d.times.length > 0
+    ? new Date(d.times[0]).getTime() + 7 * 24 * 3600 * 1000
+    : Infinity;
+  const divXs = portrait ? dayDivs(d.times)
+    .filter(i => new Date(d.times[i]).getTime() < extThreshMsAll)
+    .map(i => i * portraitColW) : null;
 
   drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
   drawWindDir(d.times, d.winds, d.dirs, totalCssW);

--- a/config.js
+++ b/config.js
@@ -1,7 +1,8 @@
 /* ══════════════════════════════════════════════════
    CONFIG
 ══════════════════════════════════════════════════ */
-const FORECAST_DAYS = 7;
+var FORECAST_DAYS = 7;
+var FORECAST_DAYS_EXTENDED = 16;
 const STEP   = 3; // every 3 hours  (icons, wind arrows)
 const STEP1H = 1; // every 1 hour   (temperature, wind speed/gust, precip curves)
 const DA_DAYS  = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
@@ -63,6 +64,20 @@ function parseKiteParams() {
 }
 
 let KITE_CFG = parseKiteParams();
+
+/* ── Forecast range (7 or 16 days) ── */
+(function() {
+  const v = parseInt(new URLSearchParams(window.location.search).get('forecast_days'));
+  if (v === FORECAST_DAYS_EXTENDED) FORECAST_DAYS = FORECAST_DAYS_EXTENDED;
+})();
+
+function setForecastDays(n) {
+  FORECAST_DAYS = n;
+  const url = new URL(window.location.href);
+  if (n === 7) url.searchParams.delete('forecast_days');
+  else url.searchParams.set('forecast_days', n);
+  window.history.replaceState(null, '', url.toString());
+}
 
 function setKiteParams(cfg) {
   KITE_CFG = cfg;

--- a/config.js
+++ b/config.js
@@ -1,8 +1,7 @@
 /* ══════════════════════════════════════════════════
    CONFIG
 ══════════════════════════════════════════════════ */
-var FORECAST_DAYS = 7;
-var FORECAST_DAYS_EXTENDED = 16;
+var FORECAST_DAYS = 16;
 const STEP   = 3; // every 3 hours  (icons, wind arrows)
 const STEP1H = 1; // every 1 hour   (temperature, wind speed/gust, precip curves)
 const DA_DAYS  = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
@@ -64,20 +63,6 @@ function parseKiteParams() {
 }
 
 let KITE_CFG = parseKiteParams();
-
-/* ── Forecast range (7 or 16 days) ── */
-(function() {
-  const v = parseInt(new URLSearchParams(window.location.search).get('forecast_days'));
-  if (v === FORECAST_DAYS_EXTENDED) FORECAST_DAYS = FORECAST_DAYS_EXTENDED;
-})();
-
-function setForecastDays(n) {
-  FORECAST_DAYS = n;
-  const url = new URL(window.location.href);
-  if (n === 7) url.searchParams.delete('forecast_days');
-  else url.searchParams.set('forecast_days', n);
-  window.history.replaceState(null, '', url.toString());
-}
 
 function setKiteParams(cfg) {
   KITE_CFG = cfg;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -15,6 +15,36 @@ function makeFakeEnsemble(varName, memberCount, hourCount, baseVal = 0, step = 2
   return H;
 }
 
+describe('fetchEnsemble – forecast_days capped per model', () => {
+  it('caps forecast_days to 7 for icon_seamless even when FORECAST_DAYS=16', async () => {
+    const ctx = loadScripts('config.js', 'api.js');
+    ctx.FORECAST_DAYS = 16;
+    let capturedUrl = '';
+    ctx.fetch = (url) => { capturedUrl = url; return Promise.reject(new Error('stop')); };
+    await ctx.fetchEnsemble(55.0, 12.0, 'dmi_seamless').catch(() => {});
+    expect(capturedUrl).toContain('forecast_days=7');
+    expect(capturedUrl).not.toContain('forecast_days=16');
+  });
+
+  it('caps forecast_days to 15 for ecmwf_ifs04 when FORECAST_DAYS=16', async () => {
+    const ctx = loadScripts('config.js', 'api.js');
+    ctx.FORECAST_DAYS = 16;
+    let capturedUrl = '';
+    ctx.fetch = (url) => { capturedUrl = url; return Promise.reject(new Error('stop')); };
+    await ctx.fetchEnsemble(55.0, 12.0, 'ecmwf_ifs025').catch(() => {});
+    expect(capturedUrl).toContain('forecast_days=15');
+  });
+
+  it('uses full FORECAST_DAYS for gfs025 which supports 35 days', async () => {
+    const ctx = loadScripts('config.js', 'api.js');
+    ctx.FORECAST_DAYS = 16;
+    let capturedUrl = '';
+    ctx.fetch = (url) => { capturedUrl = url; return Promise.reject(new Error('stop')); };
+    await ctx.fetchEnsemble(55.0, 12.0, 'gfs_seamless').catch(() => {});
+    expect(capturedUrl).toContain('forecast_days=16');
+  });
+});
+
 describe('ensemblePercentiles', () => {
   it('returns null when no matching members exist', () => {
     expect(ensemblePercentiles({}, 'nonexistent', 3)).toBeNull();

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -458,11 +458,12 @@ describe('renderDisplay slicing', () => {
     expect(colWs[0]).toBeGreaterThan(0);
   });
 
-  it('passes null portraitColW to renderAll in landscape mode', () => {
+  it('passes a positive numeric portraitColW to renderAll in landscape mode (extended scroll)', () => {
     const colWs = [];
     const { ctx } = loadApp({ portrait: false, renderAllSpy: (d, ic, colW) => colWs.push(colW) });
     ctx.renderDisplay(makeData(TOTAL_3H, TOTAL_1H));
-    expect(colWs[0]).toBeNull();
+    expect(colWs[0]).toBeTypeOf('number');
+    expect(colWs[0]).toBeGreaterThan(0);
   });
 
   it('includes dirs1h in sliced data passed to buildPortraitSeries', () => {
@@ -700,14 +701,18 @@ describe('buildPortraitSeries – extended 16-day mode', () => {
     expect(found12h).toBe(true);
   });
 
-  it('does not use 6h step beyond 168h+', () => {
+  it('uses between 6h and 12h steps (linear zoom) for daytime slots beyond 168h', () => {
     const ds = ctx16.buildPortraitSeries(make16DaySlice());
     const t0ms = new Date(ds.times[0]).getTime();
     for (let i = 1; i < ds.times.length; i++) {
       const dt = new Date(ds.times[i]).getTime() - new Date(ds.times[i - 1]).getTime();
       const hoursAhead = (new Date(ds.times[i - 1]).getTime() - t0ms) / 3600000;
       if (hoursAhead >= 168) {
-        expect([12 * HR, 24 * HR]).toContain(dt);
+        // Linear zoom: 6–12h steps for daytime; night entries are skipped 1h at a
+        // time so gaps between consecutive daytime pushes can be non-multiples of 3.
+        // Key properties: at least 1h (never backwards), at most 24h per visible slot.
+        expect(dt).toBeGreaterThanOrEqual(HR);
+        expect(dt).toBeLessThanOrEqual(24 * HR);
       }
     }
   });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -15,7 +15,7 @@ function makeEl(value = '') {
     value,
     style:      {},
     textContent: '',
-    classList:  { contains: () => false, add: () => {}, remove: () => {} },
+    classList:  { contains: () => false, add: () => {}, remove: () => {}, toggle: () => {} },
     addEventListener: () => {},
     getContext:  () => ({
       getImageData:  (x, y, w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
@@ -131,11 +131,13 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
     renderAll:          renderAllSpy || (() => {}),
     isKiteOptimal:      () => false,
     snapBearing:        (d) => d,
-    FORECAST_DAYS:      7,
+    FORECAST_DAYS:          7,
+    FORECAST_DAYS_EXTENDED: 16,
     STEP:               3,
     STEP1H:             1,
     KITE_DEFAULTS:      { min: 4, max: 18, dirs: [], daylight: true },
     KITE_CFG:           { min: 4, max: 18, dirs: [], daylight: true },
+    setForecastDays:    () => {},
     setKiteParams:      () => {},
     parseKiteParams:    () => ({ min: 4, max: 18, dirs: [], daylight: true }),
     SHORE_BEARINGS:     36,
@@ -657,6 +659,71 @@ describe('buildPortraitSeries', () => {
     s.otherModelsWind1h = null;
     const ds = ctx.buildPortraitSeries(s);
     expect(ds.otherModelsWind1h).toBeNull();
+  });
+});
+
+describe('buildPortraitSeries – extended 16-day mode', () => {
+  const TOTAL_1H_16D = 16 * 24;
+  const HR = 60 * 60 * 1000;
+  const BASE = new Date('2025-06-16T10:00:00.000Z');
+
+  function make16DaySlice() {
+    const iso1 = (i) => new Date(BASE.getTime() + i * HR).toISOString();
+    const num1 = () => Array(TOTAL_1H_16D).fill(0);
+    return {
+      times1h:     Array.from({ length: TOTAL_1H_16D }, (_, i) => iso1(i)),
+      codes1h:     num1(),
+      dirs1h:      num1(),
+      dirs:        num1(),
+      temps1h:     num1(),
+      precips1h:   num1(),
+      gusts1h:     num1(),
+      winds1h:     num1(),
+      ensTemp1h:   null,
+      ensWind1h:   null,
+      ensGust1h:   null,
+      ensPrecip1h: null,
+    };
+  }
+
+  const { ctx: ctx16 } = loadApp({ portrait: true });
+
+  it('uses 12h step for daytime slots beyond 7 days (168h+)', () => {
+    const ds = ctx16.buildPortraitSeries(make16DaySlice());
+    const t0ms = new Date(ds.times[0]).getTime();
+    let found12h = false;
+    for (let i = 1; i < ds.times.length; i++) {
+      const dt = new Date(ds.times[i]).getTime() - new Date(ds.times[i - 1]).getTime();
+      const hoursAhead = (new Date(ds.times[i - 1]).getTime() - t0ms) / 3600000;
+      if (hoursAhead >= 168 && dt === 12 * HR) { found12h = true; break; }
+    }
+    expect(found12h).toBe(true);
+  });
+
+  it('does not use 6h step beyond 168h+', () => {
+    const ds = ctx16.buildPortraitSeries(make16DaySlice());
+    const t0ms = new Date(ds.times[0]).getTime();
+    for (let i = 1; i < ds.times.length; i++) {
+      const dt = new Date(ds.times[i]).getTime() - new Date(ds.times[i - 1]).getTime();
+      const hoursAhead = (new Date(ds.times[i - 1]).getTime() - t0ms) / 3600000;
+      if (hoursAhead >= 168) {
+        expect([12 * HR, 24 * HR]).toContain(dt);
+      }
+    }
+  });
+
+  it('extended series xFrac1h values are monotonically increasing', () => {
+    const ds = ctx16.buildPortraitSeries(make16DaySlice());
+    const xf = ds.xFrac1h;
+    for (let i = 1; i < xf.length; i++) {
+      expect(xf[i]).toBeGreaterThan(xf[i - 1]);
+    }
+  });
+
+  it('extended series has fewer display slots than 1h input slots', () => {
+    const s = make16DaySlice();
+    const ds = ctx16.buildPortraitSeries(s);
+    expect(ds.times.length).toBeLessThan(s.times1h.length);
   });
 });
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -146,3 +146,48 @@ describe('kite settings – localStorage persistence (iOS Home Screen fix)', () 
     expect(cfg.daylight).toBe(false);
   });
 });
+
+describe('forecast range – setForecastDays', () => {
+  it('FORECAST_DAYS defaults to 7', () => {
+    const ctx = loadScripts('config.js');
+    expect(ctx.FORECAST_DAYS).toBe(7);
+  });
+
+  it('FORECAST_DAYS_EXTENDED is 16', () => {
+    const ctx = loadScripts('config.js');
+    expect(ctx.FORECAST_DAYS_EXTENDED).toBe(16);
+  });
+
+  it('setForecastDays(16) updates FORECAST_DAYS to 16', () => {
+    const ctx = loadScripts('config.js');
+    ctx.setForecastDays(16);
+    expect(ctx.FORECAST_DAYS).toBe(16);
+  });
+
+  it('setForecastDays(7) resets FORECAST_DAYS to 7', () => {
+    const ctx = loadScripts('config.js');
+    ctx.setForecastDays(16);
+    ctx.setForecastDays(7);
+    expect(ctx.FORECAST_DAYS).toBe(7);
+  });
+
+  it('setForecastDays(16) adds forecast_days=16 to URL', () => {
+    const calls = [];
+    const ctx = loadScripts('config.js');
+    ctx.window.history.replaceState = (...a) => calls.push(a);
+    ctx.setForecastDays(16);
+    expect(calls.length).toBeGreaterThan(0);
+    const url = calls[calls.length - 1][2];
+    expect(url).toContain('forecast_days=16');
+  });
+
+  it('setForecastDays(7) removes forecast_days from URL', () => {
+    const calls = [];
+    const ctx = loadScripts('config.js');
+    ctx.window.history.replaceState = (...a) => calls.push(a);
+    ctx.setForecastDays(16);
+    ctx.setForecastDays(7);
+    const url = calls[calls.length - 1][2];
+    expect(url).not.toContain('forecast_days');
+  });
+});

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -147,47 +147,9 @@ describe('kite settings – localStorage persistence (iOS Home Screen fix)', () 
   });
 });
 
-describe('forecast range – setForecastDays', () => {
-  it('FORECAST_DAYS defaults to 7', () => {
+describe('forecast range', () => {
+  it('FORECAST_DAYS is 16 (always shows full 16-day forecast)', () => {
     const ctx = loadScripts('config.js');
-    expect(ctx.FORECAST_DAYS).toBe(7);
-  });
-
-  it('FORECAST_DAYS_EXTENDED is 16', () => {
-    const ctx = loadScripts('config.js');
-    expect(ctx.FORECAST_DAYS_EXTENDED).toBe(16);
-  });
-
-  it('setForecastDays(16) updates FORECAST_DAYS to 16', () => {
-    const ctx = loadScripts('config.js');
-    ctx.setForecastDays(16);
     expect(ctx.FORECAST_DAYS).toBe(16);
-  });
-
-  it('setForecastDays(7) resets FORECAST_DAYS to 7', () => {
-    const ctx = loadScripts('config.js');
-    ctx.setForecastDays(16);
-    ctx.setForecastDays(7);
-    expect(ctx.FORECAST_DAYS).toBe(7);
-  });
-
-  it('setForecastDays(16) adds forecast_days=16 to URL', () => {
-    const calls = [];
-    const ctx = loadScripts('config.js');
-    ctx.window.history.replaceState = (...a) => calls.push(a);
-    ctx.setForecastDays(16);
-    expect(calls.length).toBeGreaterThan(0);
-    const url = calls[calls.length - 1][2];
-    expect(url).toContain('forecast_days=16');
-  });
-
-  it('setForecastDays(7) removes forecast_days from URL', () => {
-    const calls = [];
-    const ctx = loadScripts('config.js');
-    ctx.window.history.replaceState = (...a) => calls.push(a);
-    ctx.setForecastDays(16);
-    ctx.setForecastDays(7);
-    const url = calls[calls.length - 1][2];
-    expect(url).not.toContain('forecast_days');
   });
 });

--- a/vejr.css
+++ b/vejr.css
@@ -158,10 +158,17 @@ body {
   flex: 1;
   min-width: 0;
   position: relative;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
+  cursor: grab;
 }
+.chart-canvas-wrap::-webkit-scrollbar { display: none; }
 .y-axis-right {
   flex: 0 0 36px;
   width: 36px;
@@ -416,37 +423,6 @@ canvas.main-canvas {
   flex-shrink: 0;
 }
 #kite-cfg-btn:hover { background: #225a38; }
-
-#forecast-range-btn {
-  padding: 5px 8px;
-  background: #1e2e44;
-  color: #7ab8f5;
-  border: 1px solid #4a7ab5;
-  border-radius: 3px;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  letter-spacing: 0.3px;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-#forecast-range-btn:hover { background: #253d58; }
-#forecast-range-btn.active {
-  background: #003c8f;
-  color: #b8d4ff;
-  border-color: #6699cc;
-}
-
-/* Landscape extended forecast: enable horizontal scroll on chart rows */
-body.forecast-extended .chart-canvas-wrap {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior-x: contain;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-body.forecast-extended .chart-canvas-wrap::-webkit-scrollbar { display: none; }
 
 /* ── App footer ── */
 #app-footer {
@@ -1049,20 +1025,8 @@ body.inverted-colors #help-btn:hover { background: #c5b59f; }
   .y-axis-right { display: none; }
 }
 
-/* ── Portrait: horizontally scrollable canvas area ── */
-/*    Each .chart-canvas-wrap is its own scroll container; JS syncs them.   */
-/*    The .y-axis siblings stay fixed — no sticky needed.                   */
+/* ── Portrait: footer layout ── */
 @media (orientation: portrait) {
-  .chart-canvas-wrap {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    overscroll-behavior-x: contain;
-    /* Hide scrollbar chrome — scrolling still works via swipe/drag */
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  .chart-canvas-wrap::-webkit-scrollbar { display: none; }
-
   /* Footer portrait: grid with shore-status+help+credits on row 1, build-number below */
   #app-footer {
     display: grid;

--- a/vejr.css
+++ b/vejr.css
@@ -417,6 +417,37 @@ canvas.main-canvas {
 }
 #kite-cfg-btn:hover { background: #225a38; }
 
+#forecast-range-btn {
+  padding: 5px 8px;
+  background: #1e2e44;
+  color: #7ab8f5;
+  border: 1px solid #4a7ab5;
+  border-radius: 3px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+#forecast-range-btn:hover { background: #253d58; }
+#forecast-range-btn.active {
+  background: #003c8f;
+  color: #b8d4ff;
+  border-color: #6699cc;
+}
+
+/* Landscape extended forecast: enable horizontal scroll on chart rows */
+body.forecast-extended .chart-canvas-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+body.forecast-extended .chart-canvas-wrap::-webkit-scrollbar { display: none; }
+
 /* ── App footer ── */
 #app-footer {
   width: 100%;

--- a/vejr.html
+++ b/vejr.html
@@ -64,7 +64,6 @@
       </div>
       <div id="header-right">
         <div id="header-controls">
-          <button id="forecast-range-btn" title="Toggle forecast length">7d</button>
           <button id="kite-cfg-btn" title="Kitesurfing settings">⚙ 🪁</button>
         </div>
         <div id="model-dropdown">

--- a/vejr.html
+++ b/vejr.html
@@ -64,6 +64,7 @@
       </div>
       <div id="header-right">
         <div id="header-controls">
+          <button id="forecast-range-btn" title="Toggle forecast length">7d</button>
           <button id="kite-cfg-btn" title="Kitesurfing settings">⚙ 🪁</button>
         </div>
         <div id="model-dropdown">


### PR DESCRIPTION
## Summary
Extends the forecast range from 7 to 16 days with intelligent variable-resolution display modes. Days 1–7 use standard resolution (1h in portrait, 3h in landscape), while days 8–16 employ linear zoom with progressively coarser time steps and nighttime skipping to keep the extended forecast readable.

## Key Changes

**Forecast Range & Data**
- Extended `FORECAST_DAYS` from 7 to 16 days
- Added `FORECAST_DAYS_EXTENDED` constant (16) and `setForecastDays()` function
- Capped ensemble model requests to their supported maximums (icon_seamless: 7 days, ecmwf_ifs04: 15 days, gfs025: 35 days)

**Portrait Mode Display (buildPortraitSeries)**
- Days 0–24h: 1h slots (daytime) / 3h slots (nighttime)
- Days 24–48h: 3h slots (daytime) / 6h slots (nighttime)
- Days 48–168h: 6h slots (uniform)
- Days 168–384h: Linear zoom from 6h→12h for daytime only; nighttime slots skipped entirely

**Landscape Mode Display (new buildLandscapeSeries)**
- Days 1–7: Uniform 3h slots (fills viewport exactly at base column width)
- Days 8–16: Daytime-only with linear zoom (6h→12h), accessible via horizontal scroll
- Computed column width dynamically from viewport to ensure 7-day window fills screen

**UI & Interaction**
- Added mouse drag support for desktop panning with momentum deceleration
- Improved crosshair tracking to use `xMap1h` for accurate 1h-resolution positioning
- Updated tooltip logic to detect portrait mode via `isPortraitMode` flag
- Suppressed hour tick marks and day dividers in extended zone (days 8–16) for clarity
- Extended zone day labels show day-of-month instead of weekday names

**Visual Refinements**
- Wind/temperature curves skip null values gracefully (no flat lines for missing data)
- Improved binary search for hover detection on xMap1h
- Momentum scrolling with configurable deceleration

## Implementation Details
- Variable-resolution slots use "most daytime" heuristic to pick representative hour within coarse windows
- Linear zoom formula: `step = ceil((6 + 6 * ratio) / 3) * 3` snaps to 6h, 9h, or 12h
- Portrait and landscape modes now both use `buildPortraitSeries` and `buildLandscapeSeries` respectively, with consistent slot selection logic
- Scroll synchronization updated to handle both portrait (center "now") and landscape (left-align "now") positioning

https://claude.ai/code/session_01L6Fwy6JKdLHEhsggzpx3e3