### PR TITLE
Fix wind axis width: base Y scale on mean wind, not gusts

### DIFF
--- a/app.js
+++ b/app.js
@@ -537,8 +537,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const WIND_H = 130, WIND_KITE_H = 24, WIND_padT = WIND_KITE_H + 4;
   const WIND_chartH = WIND_H - WIND_padT;
   const safeGusts  = d.gusts.map((g, i) => Math.max(g, d.winds[i]));
-  const ensGustMax = d.ensGust ? Math.max(...d.ensGust.p90.filter(v => v != null)) : 0;
-  const maxW       = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
+  const maxW       = _windAxisMax(d.winds, d.ensWind || null);
   const windDotY   = WIND_padT + (1 - d.winds[idx3h] / maxW) * WIND_chartH;
   const fracX3h    = (idx3h + 0.5) / d.times.length;
   // xMap1h[idx1h] is the CSS x-centre of the 1h point as drawn by drawTemp.

--- a/app.js
+++ b/app.js
@@ -536,8 +536,14 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const tempDotY = tempVal != null ? TEMP_padT + (1 - (tempVal - tmin) / tRange) * TEMP_ch : null;
   const WIND_H = 130, WIND_KITE_H = 24, WIND_padT = WIND_KITE_H + 4;
   const WIND_chartH = WIND_H - WIND_padT;
-  const safeGusts  = d.gusts.map((g, i) => Math.max(g, d.winds[i]));
-  const maxW       = _windAxisMax(d.winds, d.ensWind || null);
+  const t0Ms   = d.times.length > 0 ? new Date(d.times[0]).getTime() : 0;
+  const ext7d  = t0Ms + 7 * 24 * 3600 * 1000;
+  const n7d    = d.times.findIndex(t => new Date(t).getTime() >= ext7d);
+  const nAx    = n7d > 0 ? n7d : d.times.length;
+  const maxW   = _windAxisMax(
+    d.winds.slice(0, nAx),
+    d.ensWind ? { p90: d.ensWind.p90.slice(0, nAx) } : null
+  );
   const windDotY   = WIND_padT + (1 - d.winds[idx3h] / maxW) * WIND_chartH;
   const fracX3h    = (idx3h + 0.5) / d.times.length;
   // xMap1h[idx1h] is the CSS x-centre of the 1h point as drawn by drawTemp.

--- a/charts.js
+++ b/charts.js
@@ -700,10 +700,12 @@ function _otherModelLineColor(invertedColors) {
   return invertedColors ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.35)';
 }
 
-/** Returns the wind Y-axis maximum: max mean wind speed (not gusts) rounded up to nearest 5 m/s. */
+/** Returns the wind Y-axis maximum: max ensemble wind p90 (or mean wind when no ensemble) rounded up to nearest 5 m/s. Gusts are clipped above this. */
 function _windAxisMax(winds, ensWind) {
-  const ensWindMax = ensWind ? Math.max(...ensWind.p90.filter(v => v != null)) : 0;
-  return Math.ceil(Math.max(...winds.filter(v => v != null), ensWindMax, 5) / 5) * 5;
+  const base = ensWind
+    ? Math.max(...ensWind.p90.filter(v => v != null))
+    : Math.max(...winds.filter(v => v != null));
+  return Math.ceil(Math.max(base, 5) / 5) * 5;
 }
 function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null, otherModelsWind = null, otherModelsXMap = null) {
   // --- canvas setup ---

--- a/charts.js
+++ b/charts.js
@@ -699,6 +699,12 @@ function _drawWindAxisLabels(wLevels, wy, WIND_H) {
 function _otherModelLineColor(invertedColors) {
   return invertedColors ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.35)';
 }
+
+/** Returns the wind Y-axis maximum: max mean wind speed (not gusts) rounded up to nearest 5 m/s. */
+function _windAxisMax(winds, ensWind) {
+  const ensWindMax = ensWind ? Math.max(...ensWind.p90.filter(v => v != null)) : 0;
+  return Math.ceil(Math.max(...winds.filter(v => v != null), ensWindMax, 5) / 5) * 5;
+}
 function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null, otherModelsWind = null, otherModelsXMap = null) {
   // --- canvas setup ---
   const canvas = document.getElementById('c-wind');
@@ -727,10 +733,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   const KITE_H    = 24;                   // reserved strip for kite pill icons
   const padT      = KITE_H + 4;
   const chartH    = WIND_H - padT;
-  const ensGustMax = ensGust
-    ? Math.max(...ensGust.p90.filter(v => v != null))
-    : 0;
-  const maxW      = Math.ceil(Math.max(...safeGusts, ensGustMax, 5) / 5) * 5;
+  const maxW      = _windAxisMax(winds, ensWind);
   const wy        = v => cY + padT + (1 - v / maxW) * chartH;
   const base      = wy(0);
   const wLevels   = []; for (let v = 0; v <= maxW; v += 5) wLevels.push(v);
@@ -850,6 +853,9 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   if (window.DMI_OBS && window.DMI_OBS.obs && window.DMI_OBS.obs.length) {
     const displayMs = times.map(t => new Date(t).getTime());
     ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, cY + padT, cssW, chartH);
+    ctx.clip();
     for (const ob of window.DMI_OBS.obs) {
       // Find which display slot ob.t falls into and compute the fractional offset
       // within that slot.  For 1-hour uniform slots this reduces to (fracH+0.5)*colW.

--- a/charts.js
+++ b/charts.js
@@ -700,7 +700,8 @@ function _otherModelLineColor(invertedColors) {
   return invertedColors ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.35)';
 }
 
-/** Returns the wind Y-axis maximum: max ensemble wind p90 (or mean wind when no ensemble) rounded up to nearest 5 m/s. Gusts are clipped above this. */
+/** Returns the wind Y-axis maximum: max ensemble wind p90 (or mean wind when no ensemble) rounded up to nearest 5 m/s.
+ *  Caller should pre-slice winds/ensWind to the desired window (e.g. first 7 days) before calling. */
 function _windAxisMax(winds, ensWind) {
   const base = ensWind
     ? Math.max(...ensWind.p90.filter(v => v != null))
@@ -735,7 +736,15 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   const KITE_H    = 24;                   // reserved strip for kite pill icons
   const padT      = KITE_H + 4;
   const chartH    = WIND_H - padT;
-  const maxW      = _windAxisMax(winds, ensWind);
+  // Axis max is based on the first-7-day window only; extended-forecast data
+  // (days 7–16) is drawn but clipped to this ceiling so a distant storm does
+  // not widen the scale for the current detailed period.
+  const n7d  = times.findIndex(t => new Date(t).getTime() >= extThreshMsWind);
+  const nAx  = n7d > 0 ? n7d : n;
+  const maxW = _windAxisMax(
+    winds.slice(0, nAx),
+    ensWind ? { p90: ensWind.p90.slice(0, nAx) } : null
+  );
   const wy        = v => cY + padT + (1 - v / maxW) * chartH;
   const base      = wy(0);
   const wLevels   = []; for (let v = 0; v <= maxW; v += 5) wLevels.push(v);
@@ -762,10 +771,17 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
     ctx.beginPath(); ctx.moveTo(x, cY); ctx.lineTo(x, cY + WIND_H); ctx.stroke();
   });
 
+  // Clip all data rendering to the chart area so extended-forecast values that
+  // exceed maxW don't bleed into the kite-pill strip above.
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, cY + padT, cssW, chartH);
+  ctx.clip();
+
   // --- ensemble gust band (clipped above ens-wind p90) ---
   _drawEnsGustExtendedBand(ctx, ensGust, ensWind, safeGusts, winds, n, cx2, wy, cY + padT, cssW);
 
-  // --- ensemble wind band (unclipped) ---
+  // --- ensemble wind band ---
   _drawEnsWindBand(ctx, ensWind, cx2, wy, 'rgba(0,0,0,0.22)');
 
 
@@ -816,6 +832,8 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
 
   // --- wind line ---
   _drawWindLine(ctx, winds, cx2, wy, 'rgba(255,255,255,0.95)', 2);
+
+  ctx.restore(); // end data clip
 
   // --- kite pill icons (top strip) — drawn at 3hr positions ---
   if (lastData) {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -346,15 +346,19 @@ describe('_windAxisMax', () => {
     expect(ctx._windAxisMax([5, 5, 5], null)).toBe(5);
   });
 
-  it('is based on mean wind, not gusts — high gusts do not widen the axis', () => {
-    // winds peak at 8 m/s → axis max should be 10, not 25 from the gust
+  it('uses mean wind as fallback when no ensemble data', () => {
     expect(ctx._windAxisMax([5, 8, 6], null)).toBe(10);
   });
 
-  it('includes ensemble wind p90 in the max calculation', () => {
-    // winds top out at 8 but ensemble p90 reaches 13 → rounds up to 15
+  it('uses ensemble wind p90 as the axis ceiling when ensemble is present', () => {
     const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
     expect(ctx._windAxisMax([5, 8, 6], ensWind)).toBe(15);
+  });
+
+  it('uses p90 exclusively when ensemble is present, ignoring mean winds', () => {
+    // mean winds reach 17 but p90 only 13 → axis is 15, not 20
+    const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
+    expect(ctx._windAxisMax([5, 17, 6], ensWind)).toBe(15);
   });
 
   it('filters null values in winds array', () => {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -361,6 +361,16 @@ describe('_windAxisMax', () => {
     expect(ctx._windAxisMax([5, 17, 6], ensWind)).toBe(15);
   });
 
+  it('caller-sliced arrays exclude extended-forecast high values', () => {
+    // Full 10-slot p90 has a distant storm (22 m/s) in slots 7-9; caller passes
+    // only the first 7 slots so the axis stays at 15 instead of 25.
+    const full    = [10, 12, 11, 9, 10, 11, 12, 22, 22, 22];
+    const ensWind = { p90: full };
+    expect(ctx._windAxisMax([5, 5, 5], { p90: full.slice(0, 7) })).toBe(15);
+    // Confirm without slicing the storm pushes it to 25.
+    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(25);
+  });
+
   it('filters null values in winds array', () => {
     expect(ctx._windAxisMax([null, 12, null], null)).toBe(15);
   });

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -329,3 +329,40 @@ describe('isKiteDirOnly is a superset of isKiteOptimal', () => {
     }
   });
 });
+
+// ── _windAxisMax ─────────────────────────────────────────────────────────────
+
+describe('_windAxisMax', () => {
+  let ctx;
+  beforeEach(() => { ctx = loadChartLogic(); });
+
+  it('returns minimum 5 when all winds are calm', () => {
+    expect(ctx._windAxisMax([0, 0, 0], null)).toBe(5);
+  });
+
+  it('rounds up to the nearest 5', () => {
+    expect(ctx._windAxisMax([7, 8, 6], null)).toBe(10);
+    expect(ctx._windAxisMax([10, 11, 9], null)).toBe(15);
+    expect(ctx._windAxisMax([5, 5, 5], null)).toBe(5);
+  });
+
+  it('is based on mean wind, not gusts — high gusts do not widen the axis', () => {
+    // winds peak at 8 m/s → axis max should be 10, not 25 from the gust
+    expect(ctx._windAxisMax([5, 8, 6], null)).toBe(10);
+  });
+
+  it('includes ensemble wind p90 in the max calculation', () => {
+    // winds top out at 8 but ensemble p90 reaches 13 → rounds up to 15
+    const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
+    expect(ctx._windAxisMax([5, 8, 6], ensWind)).toBe(15);
+  });
+
+  it('filters null values in winds array', () => {
+    expect(ctx._windAxisMax([null, 12, null], null)).toBe(15);
+  });
+
+  it('filters null values in ensWind.p90', () => {
+    const ensWind = { p90: [null, 14, null], p10: [null, 7, null] };
+    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(15);
+  });
+});


### PR DESCRIPTION
The axis max is now derived from the wind speed series (and ensemble wind
p90) rounded up to the nearest 5 m/s, so a calm day with high gusts no
longer stretches the scale unnecessarily. Gusts that exceed the axis
are visually clipped. DMI observation dots are now canvas-clipped to the
chart area so overflowing gust dots don't bleed into the kite pill strip.

Closes #99

https://claude.ai/code/session_01XiGGB9nMkhHG2GMtJaEicG