### PR TITLE
Add issue naming guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@
 
 ---
 
+## Issue Naming
+
+**When starting work on a GitHub issue, suggest a `/rename` command** so the conversation can be named consistently. Output this at the very start, before any other work:
+
+> `/rename Issue #XX: <issue title>`
+
+---
+
 ## CSS Version Bump
 
 **Always bump the CSS version when editing `vejr.css`.** The service worker caches `vejr.css` by URL, so changes won't reach users without a version bump. Update the query string in `vejr.html`:


### PR DESCRIPTION
## Summary
Added documentation guidance for naming GitHub issue conversations consistently using the `/rename` command.

## Changes
- Added new "Issue Naming" section to CLAUDE.md
- Documents the convention of suggesting `/rename Issue #XX: <issue title>` at the start of work on a GitHub issue
- Positioned before other guidelines to emphasize this as an early step in the workflow

## Details
This guidance helps maintain consistent conversation naming across GitHub issues, making it easier to track and reference work in progress.

https://claude.ai/code/session_01J8jh76gZsrTtwUysKhrz8g