### PR TITLE
Align wind chart to 1h data and add crosshair labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -522,9 +522,8 @@ function clearCrosshairs() {
 function drawCrosshairs(fracX, idx1h, idx3h) {
   if (!lastRenderedData) return;
   const d = lastRenderedData;
-  // renderAll always fires the portrait branch (colW is always non-null), so:
-  //   drawTemp  uses d.temps1h + d.xMap1h  → temp dot tracks xMap1h[idx1h]
-  //   drawWind  uses d.winds/d.gusts (3h)  → wind dot tracks fracX3h
+  // Both temp and wind charts use 1h data + xMap1h for smooth rendering.
+  // Kite icons / top row / direction row snap to 3h columns (fracX3h).
   const TEMP_cssH = 130, TEMP_padT = 8, TEMP_padB = 8;
   const TEMP_ch   = TEMP_cssH - TEMP_padT - TEMP_padB;
   const validTemps = d.temps1h.filter(v => v != null);
@@ -534,22 +533,25 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const tRange  = tmax - tmin;
   const tempVal = d.temps1h[idx1h];
   const tempDotY = tempVal != null ? TEMP_padT + (1 - (tempVal - tmin) / tRange) * TEMP_ch : null;
-  const WIND_H = 130;
-  const t0Ms   = d.times.length > 0 ? new Date(d.times[0]).getTime() : 0;
-  const ext7d  = t0Ms + 7 * 24 * 3600 * 1000;
-  const n7d    = d.times.findIndex(t => new Date(t).getTime() >= ext7d);
-  const nAx    = n7d > 0 ? n7d : d.times.length;
-  const maxW   = _windAxisMax(
-    d.winds.slice(0, nAx),
-    d.ensWind ? { p90: d.ensWind.p90.slice(0, nAx) } : null
+  const WIND_H  = 130;
+  const winds1h = d.winds1h || d.winds;
+  const ens1h   = d.ensWind1h || d.ensWind;
+  const times1h = d.times1h || d.times;
+  const t0Ms    = times1h.length > 0 ? new Date(times1h[0]).getTime() : 0;
+  const ext7d   = t0Ms + 7 * 24 * 3600 * 1000;
+  const n7d     = times1h.findIndex(t => new Date(t).getTime() >= ext7d);
+  const nAx     = n7d > 0 ? n7d : winds1h.length;
+  const maxW    = _windAxisMax(
+    winds1h.slice(0, nAx),
+    ens1h ? { p90: ens1h.p90.slice(0, nAx) } : null
   );
-  const windVal    = d.winds[idx3h];
+  const windVal    = winds1h[idx1h];
   const windDotY   = windVal != null ? (1 - windVal / maxW) * WIND_H : null;
   const fracX3h    = (idx3h + 0.5) / d.times.length;
-  // xMap1h[idx1h] is the CSS x-centre of the 1h point as drawn by drawTemp.
-  const tempXabs   = d.xMap1h ? d.xMap1h[idx1h] : fracX3h;
+  // xMap1h[idx1h] gives the CSS x-centre as drawn by both drawTemp and drawWind.
+  const absX1h     = d.xMap1h ? d.xMap1h[idx1h] : fracX3h;
   const DOT_Y = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
-  const FRAC  = { 'xh-top': fracX3h, 'xh-temp': null, 'xh-dir': fracX3h, 'xh-wind': fracX3h };
+  const FRAC  = { 'xh-top': fracX3h, 'xh-temp': null, 'xh-dir': fracX3h, 'xh-wind': null };
   XH_CANVASES.forEach(id => {
     const c   = document.getElementById(id);
     const ref = document.getElementById(XH_PAIR[id]);
@@ -566,7 +568,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     ctx.clearRect(0, 0, c.width, c.height);
     ctx.save();
     ctx.scale(dpr, dpr);
-    const x = (id === 'xh-temp') ? tempXabs : (FRAC[id] * cssW);
+    const x = (id === 'xh-temp' || id === 'xh-wind') ? absX1h : (FRAC[id] * cssW);
     ctx.strokeStyle = 'rgba(255,255,255,0.7)';
     ctx.lineWidth   = 1;
     ctx.setLineDash([4, 3]);

--- a/app.js
+++ b/app.js
@@ -534,8 +534,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const tRange  = tmax - tmin;
   const tempVal = d.temps1h[idx1h];
   const tempDotY = tempVal != null ? TEMP_padT + (1 - (tempVal - tmin) / tRange) * TEMP_ch : null;
-  const WIND_H = 130, WIND_KITE_H = 24, WIND_padT = WIND_KITE_H + 4;
-  const WIND_chartH = WIND_H - WIND_padT;
+  const WIND_H = 130;
   const t0Ms   = d.times.length > 0 ? new Date(d.times[0]).getTime() : 0;
   const ext7d  = t0Ms + 7 * 24 * 3600 * 1000;
   const n7d    = d.times.findIndex(t => new Date(t).getTime() >= ext7d);
@@ -544,7 +543,8 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     d.winds.slice(0, nAx),
     d.ensWind ? { p90: d.ensWind.p90.slice(0, nAx) } : null
   );
-  const windDotY   = WIND_padT + (1 - d.winds[idx3h] / maxW) * WIND_chartH;
+  const windVal    = d.winds[idx3h];
+  const windDotY   = windVal != null ? (1 - windVal / maxW) * WIND_H : null;
   const fracX3h    = (idx3h + 0.5) / d.times.length;
   // xMap1h[idx1h] is the CSS x-centre of the 1h point as drawn by drawTemp.
   const tempXabs   = d.xMap1h ? d.xMap1h[idx1h] : fracX3h;
@@ -582,6 +582,29 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
       ctx.arc(x, dotY, 4, 0, Math.PI * 2);
       ctx.fill();
       ctx.stroke();
+      // inline label next to the dot
+      ctx.font         = 'bold 10px monospace';
+      ctx.textBaseline = 'middle';
+      const nearRight  = x + 52 > cssW;
+      ctx.textAlign    = nearRight ? 'right' : 'left';
+      const labelX     = nearRight ? x - 8 : x + 8;
+      if (id === 'xh-temp' && tempVal != null) {
+        ctx.fillStyle = dotCol;
+        ctx.fillText(`${tempVal >= 0 ? '+' : ''}${tempVal.toFixed(1)}°`, labelX, dotY);
+      } else if (id === 'xh-wind' && windVal != null) {
+        ctx.fillStyle = windColorStr(windVal, 1);
+        ctx.fillText(windVal.toFixed(1), labelX, dotY);
+      }
+    }
+    // time label at the bottom of the top-row overlay
+    if (id === 'xh-top') {
+      const t  = new Date(d.times[idx3h]);
+      const hh = t.getHours().toString().padStart(2, '0');
+      ctx.font         = 'bold 10px sans-serif';
+      ctx.fillStyle    = '#000';
+      ctx.textBaseline = 'bottom';
+      ctx.textAlign    = 'center';
+      ctx.fillText(`${hh}:00`, x, cssH - 2);
     }
     ctx.restore();
   });

--- a/app.js
+++ b/app.js
@@ -584,15 +584,14 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
       ctx.stroke();
       // inline label next to the dot
       ctx.font         = 'bold 10px monospace';
+      ctx.fillStyle    = '#000';
       ctx.textBaseline = 'middle';
       const nearRight  = x + 52 > cssW;
       ctx.textAlign    = nearRight ? 'right' : 'left';
       const labelX     = nearRight ? x - 8 : x + 8;
       if (id === 'xh-temp' && tempVal != null) {
-        ctx.fillStyle = dotCol;
         ctx.fillText(`${tempVal >= 0 ? '+' : ''}${tempVal.toFixed(1)}°`, labelX, dotY);
       } else if (id === 'xh-wind' && windVal != null) {
-        ctx.fillStyle = windColorStr(windVal, 1);
         ctx.fillText(windVal.toFixed(1), labelX, dotY);
       }
     }
@@ -604,7 +603,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
       ctx.fillStyle    = '#000';
       ctx.textBaseline = 'bottom';
       ctx.textAlign    = 'center';
-      ctx.fillText(`${hh}:00`, x, cssH - 2);
+      ctx.fillText(`${hh}:00`, x, cssH + 3);
     }
     ctx.restore();
   });

--- a/app.js
+++ b/app.js
@@ -603,7 +603,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
       ctx.fillStyle    = '#000';
       ctx.textBaseline = 'bottom';
       ctx.textAlign    = 'center';
-      ctx.fillText(`${hh}:00`, x, cssH + 3);
+      ctx.fillText(`${hh}:00`, x, cssH);
     }
     ctx.restore();
   });

--- a/charts.js
+++ b/charts.js
@@ -864,12 +864,14 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   }
 
   // --- DMI observed wind dots ---
-  // Yellow dots  = 10-min mean wind speed from the nearest DMI station.
-  // Orange dots  = 10-min gust (wind_gust_always_10min) — faint, drawn first so
-  //                the wind dots appear on top.
-  // x-mapping: slot-aware position so portrait variable-resolution slots align.
+  // Wind dots = 10-min mean wind speed from the nearest DMI station.
+  // Gust dots = 10-min gust — faint, drawn first so wind dots appear on top.
+  // x-mapping: use the 3h display series (times3h || times) because totalCssW
+  // is anchored to that series' slot count, not to times1h.
   if (window.DMI_OBS && window.DMI_OBS.obs && window.DMI_OBS.obs.length) {
-    const displayMs = times.map(t => new Date(t).getTime());
+    const obsRef    = times3h || times;
+    const obsColW   = cssW / obsRef.length;
+    const displayMs = obsRef.map(t => new Date(t).getTime());
     ctx.save();
     ctx.beginPath();
     ctx.rect(0, cY, cssW, WIND_H);
@@ -883,7 +885,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
         ? displayMs[j + 1] - displayMs[j]
         : (j > 0 ? displayMs[j] - displayMs[j - 1] : 3600000);
       const slotFrac = (ob.t - displayMs[j]) / slotDur;
-      const x = (j + slotFrac + 0.5) * colW;
+      const x = (j + slotFrac + 0.5) * obsColW;
       if (x < -8 || x > cssW + 8) continue;
       // gust dot (drawn first so wind dot appears on top)
       if (ob.gust != null && isFinite(ob.gust)) {

--- a/charts.js
+++ b/charts.js
@@ -936,8 +936,8 @@ function renderAll(d, invertedColors, portraitColW = null) {
     // divXs ensures day dividers align with the icon row regardless of curve resolution.
     drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,
              d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW, d.xMap1h || null, divXs);
-    drawWind(d.times, d.gusts, d.winds, d.dirs, d.ensWind || null, d.ensGust || null,
-             null, null, invertedColors, totalCssW, null,
+    drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
+             d.times, d.winds, invertedColors, totalCssW, d.xMap1h || null,
              d.otherModelsWind1h || null, d.xMap1h || null);
   } else {
     // Landscape: smooth 1h curves with display-series for precip bars / kite highlights.

--- a/charts.js
+++ b/charts.js
@@ -733,9 +733,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   // --- scale ---
   const safeGusts = _safeClampGusts(gusts, winds);
   const cY        = 0;
-  const KITE_H    = 24;                   // reserved strip for kite pill icons
-  const padT      = KITE_H + 4;
-  const chartH    = WIND_H - padT;
+  const KITE_H    = 24;                   // kite pill icon height (pills drawn on top of chart)
   // Axis max is based on the first-7-day window only; extended-forecast data
   // (days 7–16) is drawn but clipped to this ceiling so a distant storm does
   // not widen the scale for the current detailed period.
@@ -745,7 +743,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
     winds.slice(0, nAx),
     ensWind ? { p90: ensWind.p90.slice(0, nAx) } : null
   );
-  const wy        = v => cY + padT + (1 - v / maxW) * chartH;
+  const wy        = v => cY + (1 - v / maxW) * WIND_H;
   const base      = wy(0);
   const wLevels   = []; for (let v = 0; v <= maxW; v += 5) wLevels.push(v);
 
@@ -772,14 +770,14 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   });
 
   // Clip all data rendering to the chart area so extended-forecast values that
-  // exceed maxW don't bleed into the kite-pill strip above.
+  // exceed maxW don't overflow the canvas.
   ctx.save();
   ctx.beginPath();
-  ctx.rect(0, cY + padT, cssW, chartH);
+  ctx.rect(0, cY, cssW, WIND_H);
   ctx.clip();
 
   // --- ensemble gust band (clipped above ens-wind p90) ---
-  _drawEnsGustExtendedBand(ctx, ensGust, ensWind, safeGusts, winds, n, cx2, wy, cY + padT, cssW);
+  _drawEnsGustExtendedBand(ctx, ensGust, ensWind, safeGusts, winds, n, cx2, wy, cY, cssW);
 
   // --- ensemble wind band ---
   _drawEnsWindBand(ctx, ensWind, cx2, wy, 'rgba(0,0,0,0.22)');
@@ -874,7 +872,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
     const displayMs = times.map(t => new Date(t).getTime());
     ctx.save();
     ctx.beginPath();
-    ctx.rect(0, cY + padT, cssW, chartH);
+    ctx.rect(0, cY, cssW, WIND_H);
     ctx.clip();
     for (const ob of window.DMI_OBS.obs) {
       // Find which display slot ob.t falls into and compute the fractional offset
@@ -887,18 +885,18 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
       const slotFrac = (ob.t - displayMs[j]) / slotDur;
       const x = (j + slotFrac + 0.5) * colW;
       if (x < -8 || x > cssW + 8) continue;
-      // gust dot (faint orange — drawn first so wind dot appears on top)
+      // gust dot (drawn first so wind dot appears on top)
       if (ob.gust != null && isFinite(ob.gust)) {
         ctx.beginPath();
         ctx.arc(x, wy(ob.gust), 2.5, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(255,150,50,0.65)';
+        ctx.fillStyle = windColorStr(ob.gust, 0.65);
         ctx.fill();
       }
-      // wind dot (yellow, slightly larger and more opaque)
+      // wind dot (slightly larger and more opaque)
       if (ob.wind != null && isFinite(ob.wind)) {
         ctx.beginPath();
         ctx.arc(x, wy(ob.wind), 2.5, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(255,240,80,0.9)';
+        ctx.fillStyle = windColorStr(ob.wind, 0.9);
         ctx.strokeStyle = 'rgba(0,0,0,0.3)';
         ctx.lineWidth = 0.5;
         ctx.fill();

--- a/vejr.html
+++ b/vejr.html
@@ -387,7 +387,7 @@ Trafikinfo weather stations sometimes have unhelpful auto-generated names. If yo
 <script src="config.js?v=23"></script>
 <script src="api.js?v=23"></script>
 <script src="weather-icons.js?v=23"></script>
-<script src="charts.js?v=25"></script>
+<script src="charts.js?v=26"></script>
 <script src="radar.js?v=24"></script>
 <script src="shore.js?v=23"></script>
 <script src="app.js?v=27"></script>

--- a/vejr.html
+++ b/vejr.html
@@ -387,10 +387,10 @@ Trafikinfo weather stations sometimes have unhelpful auto-generated names. If yo
 <script src="config.js?v=23"></script>
 <script src="api.js?v=23"></script>
 <script src="weather-icons.js?v=23"></script>
-<script src="charts.js?v=24"></script>
+<script src="charts.js?v=25"></script>
 <script src="radar.js?v=24"></script>
 <script src="shore.js?v=23"></script>
-<script src="app.js?v=26"></script>
+<script src="app.js?v=27"></script>
 <!-- 100% privacy-first analytics -->
 <script data-collect-dnt="true" async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>

--- a/vejr.html
+++ b/vejr.html
@@ -387,11 +387,11 @@ Trafikinfo weather stations sometimes have unhelpful auto-generated names. If yo
 <script src="config.js?v=23"></script>
 <script src="api.js?v=23"></script>
 <script src="weather-icons.js?v=23"></script>
-<script src="charts.js?v=23"></script>
+<script src="charts.js?v=24"></script>
 <script src="radar.js?v=24"></script>
 <script src="shore.js?v=23"></script>
-<script src="app.js?v=24"></script>
+<script src="app.js?v=25"></script>
 <!-- 100% privacy-first analytics -->
-<script data-collect-dnt="true" async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>  
+<script data-collect-dnt="true" async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>
 </html>

--- a/vejr.html
+++ b/vejr.html
@@ -390,7 +390,7 @@ Trafikinfo weather stations sometimes have unhelpful auto-generated names. If yo
 <script src="charts.js?v=24"></script>
 <script src="radar.js?v=24"></script>
 <script src="shore.js?v=23"></script>
-<script src="app.js?v=25"></script>
+<script src="app.js?v=26"></script>
 <!-- 100% privacy-first analytics -->
 <script data-collect-dnt="true" async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </body>


### PR DESCRIPTION
## Summary
This PR refactors the wind chart rendering to use 1-hour data consistently with the temperature chart, and adds inline labels to crosshair overlays for better data readability.

## Key Changes

- **Wind chart data alignment**: Changed `drawWind()` to use 1h data series (`times1h`, `winds1h`, `gusts1h`, `ensWind1h`, `ensGust1h`) instead of 3h data, matching the temperature chart's smooth rendering approach
- **Crosshair positioning**: Updated `drawCrosshairs()` to position both temperature and wind dots using `xMap1h[idx1h]` for consistent 1h-based positioning, while kite icons and direction rows remain snapped to 3h columns
- **Wind chart layout simplification**: Removed separate padding for kite icons (`padT`, `KITE_H + 4`) and now use full `WIND_H` for chart scaling, with kite pills drawn on top
- **Crosshair labels**: Added inline value labels next to temperature and wind dots (e.g., "+15.2°", "8.5"), positioned intelligently to avoid canvas edges
- **Time label**: Added hour display (e.g., "14:00") at the bottom of the top-row crosshair overlay
- **DMI observation dots**: Updated to use the 3h display series for x-mapping consistency and applied `windColorStr()` for dynamic coloring instead of hardcoded colors
- **Comment clarifications**: Updated documentation to reflect that both temp and wind charts now use 1h data with xMap1h for smooth rendering

## Implementation Details

- Wind dot positioning now uses `idx1h` instead of `idx3h`, enabling smooth tracking across 1h intervals
- Crosshair label rendering includes font styling, text alignment logic, and bounds checking to prevent overflow
- The wind chart clipping region was adjusted to use the full `WIND_H` height instead of the reduced `chartH`
- DMI observation slot calculation now references the correct display series (`times3h || times`) for proper column width computation

https://claude.ai/code/session_01Gv4qFkHfjkvKz1fKPqmb6g