### PR TITLE
Fix time misalignment in wind dir row (#109) and stale obs data (#110)

### DIFF
--- a/app.js
+++ b/app.js
@@ -339,7 +339,7 @@ function _setObsStationHeader(name) {
   }
 }
 
-async function loadNearestObsStation(lat, lon) {
+async function loadNearestObsStation(lat, lon, opts = {}) {
   lastObsCoords = { lat, lon };
   window.DMI_OBS_STATUS = { state: 'loading', msg: 'loading…' };
   // Clear stale station highlight and header immediately so the old info
@@ -348,7 +348,7 @@ async function loadNearestObsStation(lat, lon) {
   if (window.highlightNearestStation) window.highlightNearestStation(null, null);
   updateDmiObsStatusUI();
   try {
-    let obsHistory = window.OBS_HISTORY;
+    let obsHistory = (opts.useCache && window.OBS_HISTORY) ? window.OBS_HISTORY : null;
     if (!obsHistory) {
       const fetchFn = window.fetchObsHistory;
       if (fetchFn) {
@@ -1119,6 +1119,12 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
     if (e.key === 'Escape') overlay.classList.remove('open');
   });
 })();
+
+// When the radar map's obs-history refresh fires, re-run nearest-station lookup
+// using the freshly populated window.OBS_HISTORY (no extra network request).
+window.onObsHistoryRefreshed = () => {
+  if (lastObsCoords) loadNearestObsStation(lastObsCoords.lat, lastObsCoords.lon, { useCache: true }).catch(() => null);
+};
 
 // Register service worker for PWA / offline support
 if ('serviceWorker' in navigator) {

--- a/charts.js
+++ b/charts.js
@@ -334,7 +334,7 @@ function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h,
 /* ══════════════════════════════════════════════════
    DRAW WIND DIRECTION ROW
 ══════════════════════════════════════════════════ */
-function drawWindDir(times, winds, dirs, totalCssW = null) {
+function drawWindDir(times, winds, dirs, totalCssW = null, divXs = null) {
   const canvas = document.getElementById('c-dir');
   const wrap   = canvas.parentElement;
   const n      = times.length;
@@ -361,12 +361,20 @@ function drawWindDir(times, winds, dirs, totalCssW = null) {
   ctx.fillRect(0, 0, cssW, DIR_H);
 
   // day dividers (first 7 days only — req #3)
-  divs.forEach(i => {
-    if (new Date(times[i]).getTime() >= extThreshMsDir) return;
-    const x = i * colW;
-    ctx.strokeStyle = 'rgba(255,255,255,0.18)'; ctx.lineWidth = 1;
-    ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, DIR_H); ctx.stroke();
-  });
+  // Use pre-computed divXs when available (portrait mode) so dividers align with other rows.
+  if (divXs) {
+    divXs.forEach(x => {
+      ctx.strokeStyle = 'rgba(255,255,255,0.18)'; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, DIR_H); ctx.stroke();
+    });
+  } else {
+    divs.forEach(i => {
+      if (new Date(times[i]).getTime() >= extThreshMsDir) return;
+      const x = i * colW;
+      ctx.strokeStyle = 'rgba(255,255,255,0.18)'; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, DIR_H); ctx.stroke();
+    });
+  }
 
   // KITE highlight — bright teal on all columns where direction matches
   dirs.forEach((deg, i) => {
@@ -835,7 +843,7 @@ function renderAll(d, invertedColors, portraitColW = null) {
     .map(i => i * portraitColW) : null;
 
   drawTopRow(d.times, d.codes, d.precips, invertedColors, totalCssW);
-  drawWindDir(d.times, d.winds, d.dirs, totalCssW);
+  drawWindDir(d.times, d.winds, d.dirs, totalCssW, divXs);
   if (portrait) {
     // Portrait: temp curve uses 1h data + xMap1h for smooth rendering across
     // the variable-resolution display grid. Precip bars use the display series.

--- a/charts.js
+++ b/charts.js
@@ -620,7 +620,7 @@ function _windAxisMax(winds, ensWind) {
     : Math.max(...winds.filter(v => v != null));
   return Math.ceil(Math.max(base, 5) / 5) * 5;
 }
-function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null, otherModelsWind = null, otherModelsXMap = null) {
+function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null, otherModelsWind = null, otherModelsXMap = null, divXs = null) {
   // --- canvas setup ---
   const canvas = document.getElementById('c-wind');
   const n      = times.length;
@@ -674,12 +674,19 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
 
   // --- grid & day dividers (first 7 days only — req #3) ---
   _drawWindGrid(ctx, wLevels, wy, cssW);
-  divs.forEach(i => {
-    if (new Date(times[i]).getTime() >= extThreshMsWind) return;
-    const x = xMap ? (xMap[i - 1] + xMap[i]) / 2 : i * colW;
-    ctx.strokeStyle = '#667788'; ctx.lineWidth = 1;
-    ctx.beginPath(); ctx.moveTo(x, cY); ctx.lineTo(x, cY + WIND_H); ctx.stroke();
-  });
+  if (divXs) {
+    divXs.forEach(x => {
+      ctx.strokeStyle = '#667788'; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(x, cY); ctx.lineTo(x, cY + WIND_H); ctx.stroke();
+    });
+  } else {
+    divs.forEach(i => {
+      if (new Date(times[i]).getTime() >= extThreshMsWind) return;
+      const x = xMap ? (xMap[i - 1] + xMap[i]) / 2 : i * colW;
+      ctx.strokeStyle = '#667788'; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(x, cY); ctx.lineTo(x, cY + WIND_H); ctx.stroke();
+    });
+  }
 
   // Clip all data rendering to the chart area so extended-forecast values that
   // exceed maxW don't overflow the canvas.
@@ -852,7 +859,7 @@ function renderAll(d, invertedColors, portraitColW = null) {
              d.times, d.precips, d.ensPrecip || null, invertedColors, totalCssW, d.xMap1h || null, divXs);
     drawWind(d.times1h, d.gusts1h, d.winds1h, d.dirs, d.ensWind1h || null, d.ensGust1h || null,
              d.times, d.winds, invertedColors, totalCssW, d.xMap1h || null,
-             d.otherModelsWind1h || null, d.xMap1h || null);
+             d.otherModelsWind1h || null, d.xMap1h || null, divXs);
   } else {
     // Landscape: smooth 1h curves with display-series for precip bars / kite highlights.
     drawTemp(d.times1h, d.temps1h, d.precips1h, d.ensTemp1h || null, d.ensPrecip1h || null,

--- a/radar.js
+++ b/radar.js
@@ -502,7 +502,7 @@ function _buildProposeNameUrl(s) {
 
       // First-time init: load wind stations and start auto-refresh
       refreshWindStations();
-      setInterval(refreshWindStations, 10 * 60 * 1000);
+      setInterval(refreshWindStations, 5 * 60 * 1000);
       initOverlayToggles();
     }
     radarMap.setView([lat, lon], 8);
@@ -958,6 +958,7 @@ function _buildProposeNameUrl(s) {
 
     if (trafikinfoVisible) trafikinfoLayer.addTo(radarMap);
     if (dmiVisible)        dmiLayer.addTo(radarMap);
+    if (window.onObsHistoryRefreshed) window.onObsHistoryRefreshed();
   }
 
   // ── DMI station markers ───────────────────────────────────────────────────

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -890,8 +890,9 @@ function loadAppWithObs(obsHistory) {
   const renderCalls = [];
   const highlightCalls = [];
   const { ctx } = loadApp({ renderAllSpy: (d) => renderCalls.push(d) });
-  // Pre-populate OBS_HISTORY and lastData so loadNearestObsStation can skip fetch.
   ctx.window.OBS_HISTORY = obsHistory;
+  // Mock fetchObsHistory so the always-fresh-fetch path gets the test data.
+  ctx.window.fetchObsHistory = async () => { ctx.window.OBS_HISTORY = obsHistory; return obsHistory; };
   ctx.lastData = makeData((7 * 24) / 3, 7 * 24);
   // Spy for map highlight
   ctx.window.highlightNearestStation = (lat, lon) => highlightCalls.push({ lat, lon });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1158,3 +1158,60 @@ describe('long press on mobile', () => {
   });
 });
 
+// ── drawCrosshairs uses xMap1h for all rows ────────────────────────────────────
+
+describe('drawCrosshairs consistent x across rows', () => {
+  it('uses xMap1h[idx1h] for all four rows, not fracX3h slot center', () => {
+    const { ctx } = loadApp();
+
+    // Stub _windAxisMax since charts.js is not loaded in app test context.
+    ctx._windAxisMax = () => 20;
+
+    // Two 3h display slots; each contains 3 1h points.
+    // xMap1h[1] = 25px, but fracX3h for slot 0 = (0+0.5)/2 * 60 = 15px.
+    // Before the fix, xh-dir and xh-top used fracX3h (15) while xh-temp and
+    // xh-wind used xMap1h (25), causing a visible crosshair jump between rows.
+    const cssW = 60;
+    ctx.lastRenderedData = {
+      times:     ['2025-01-01T00:00', '2025-01-01T03:00'],
+      times1h:   Array.from({ length: 6 }, (_, i) => `2025-01-01T0${i}:00`),
+      temps1h:   Array(6).fill(10),
+      winds1h:   Array(6).fill(5),
+      ensWind1h: null,
+      ensGust1h: null,
+      xMap1h:    [15, 25, 35, 45, 55, 65],
+      slotIdx1h: [0, 0, 0, 1, 1, 1],
+    };
+
+    const xDrawn = {};
+    function makeXhCtx(id) {
+      return {
+        clearRect() {}, save() {}, restore() {}, scale() {},
+        beginPath() {}, stroke() {}, fill() {}, arc() {},
+        setLineDash() {}, fillText() {},
+        moveTo(x) { xDrawn[id] = x; }, lineTo() {},
+        font: '', fillStyle: '', strokeStyle: '',
+        lineWidth: 0, textBaseline: '', textAlign: '',
+        measureText: () => ({ width: 0 }),
+      };
+    }
+
+    const origGetEl = ctx.document.getElementById;
+    ctx.document.getElementById = (id) => {
+      if (['xh-top', 'xh-temp', 'xh-dir', 'xh-wind'].includes(id))
+        return { width: cssW, height: 50, style: {}, getContext: () => makeXhCtx(id) };
+      if (['c-top', 'c-temp', 'c-dir', 'c-wind'].includes(id))
+        return { width: cssW, height: 50 };
+      return origGetEl(id);
+    };
+
+    // idx1h=1 → xMap1h[1]=25;  idx3h=0 → fracX3h=0.25 → fracX3h*cssW=15 (different)
+    ctx.drawCrosshairs(0.25, 1, 0);
+
+    // All four rows must be at xMap1h[1]=25, not at fracX3h*cssW=15
+    expect(xDrawn['xh-top']).toBeCloseTo(25);
+    expect(xDrawn['xh-temp']).toBeCloseTo(25);
+    expect(xDrawn['xh-dir']).toBeCloseTo(25);
+    expect(xDrawn['xh-wind']).toBeCloseTo(25);
+  });
+});

--- a/tooltip.js
+++ b/tooltip.js
@@ -39,10 +39,11 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   const windVal    = winds1h[idx1h];
   const windDotY   = windVal != null ? (1 - windVal / maxW) * WIND_H : null;
   const fracX3h    = (idx3h + 0.5) / d.times.length;
-  // xMap1h[idx1h] gives the CSS x-centre as drawn by both drawTemp and drawWind.
+  // All rows use xMap1h[idx1h] so the crosshair is at the same x in every row.
+  // This prevents the visible jump that occurred when moving between rows in
+  // coarse (3h/6h) display slots where fracX3h * cssW ≠ xMap1h[idx1h].
   const absX1h     = d.xMap1h ? d.xMap1h[idx1h] : fracX3h;
   const DOT_Y = { 'xh-top': null, 'xh-temp': tempDotY, 'xh-dir': null, 'xh-wind': windDotY };
-  const FRAC  = { 'xh-top': fracX3h, 'xh-temp': null, 'xh-dir': fracX3h, 'xh-wind': null };
   XH_CANVASES.forEach(id => {
     const c   = document.getElementById(id);
     const ref = document.getElementById(XH_PAIR[id]);
@@ -59,7 +60,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     ctx.clearRect(0, 0, c.width, c.height);
     ctx.save();
     ctx.scale(dpr, dpr);
-    const x = (id === 'xh-temp' || id === 'xh-wind') ? absX1h : (FRAC[id] * cssW);
+    const x = d.xMap1h ? d.xMap1h[idx1h] : fracX3h * cssW;
     ctx.strokeStyle = 'rgba(255,255,255,0.7)';
     ctx.lineWidth   = 1;
     ctx.setLineDash([4, 3]);
@@ -90,7 +91,7 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
     }
     // time label at the bottom of the top-row overlay
     if (id === 'xh-top') {
-      const t  = new Date(d.times[idx3h]);
+      const t  = new Date(d.times1h ? d.times1h[idx1h] : d.times[idx3h]);
       const hh = t.getHours().toString().padStart(2, '0');
       ctx.font         = 'bold 10px sans-serif';
       ctx.fillStyle    = '#000';


### PR DESCRIPTION
Issue #109: drawWindDir was computing day-divider x positions independently
as i*colW, while drawTemp and drawWind use pre-computed divXs (portrait) or
xMap midpoints. Pass divXs from renderAll into drawWindDir so all chart rows
share identical divider positions in portrait mode.

Issue #110: loadNearestObsStation was reusing the window.OBS_HISTORY cache on
location changes instead of always fetching fresh data. Now always fetches on
load (useCache:false default) and only uses the cache when called from the
onObsHistoryRefreshed callback (populated by refreshWindStations after each
periodic refresh). Reduce radar map obs refresh interval from 10 min to 5 min
and fire window.onObsHistoryRefreshed after each refresh so the sidebar
nearest-station display stays in sync without a redundant network request.

https://claude.ai/code/session_01Fmw2SErbWDKMEjMpoMcHEj