### PR TITLE
Fix wind axis span (issue #114 followup)

### DIFF
--- a/charts.js
+++ b/charts.js
@@ -612,13 +612,10 @@ function _otherModelLineColor(invertedColors) {
   return invertedColors ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.35)';
 }
 
-/** Returns the wind Y-axis maximum: max ensemble wind p90 (or mean wind when no ensemble) rounded up to nearest 5 m/s,
- *  plus 2 m/s headroom so peaks never touch the top edge.
- *  obsMax: optional max observed wind speed to include in the ceiling. */
-function _windAxisMax(winds, ensWind, obsMax = 0) {
-  const base = ensWind
-    ? Math.max(...ensWind.p90.filter(v => v != null))
-    : Math.max(...winds.filter(v => v != null));
+/** Returns the wind Y-axis maximum: max mean wind speed (the drawn line) + 2 m/s headroom.
+ *  obsMax: optional max observed wind speed (ob.wind, not ob.gust) to include. */
+function _windAxisMax(winds, obsMax = 0) {
+  const base = Math.max(...winds.filter(v => v != null));
   return Math.max(base, obsMax, 5) + 2;
 }
 function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null, otherModelsWind = null, otherModelsXMap = null, divXs = null) {
@@ -651,7 +648,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
     ? Math.max(0, ...obs.map(ob => (ob.wind != null && isFinite(ob.wind) ? ob.wind : 0)))
     : 0;
   const obsMax = _obsWindMax(window.DMI_OBS?.obs);
-  const maxW = _windAxisMax(winds, ensWind, obsMax);
+  const maxW = _windAxisMax(winds, obsMax);
   const wy        = v => cY + (1 - v / maxW) * WIND_H;
   const base      = wy(0);
   const wLevels   = []; for (let v = 0; v <= maxW; v += 5) wLevels.push(v);

--- a/charts.js
+++ b/charts.js
@@ -614,7 +614,6 @@ function _otherModelLineColor(invertedColors) {
 
 /** Returns the wind Y-axis maximum: max ensemble wind p90 (or mean wind when no ensemble) rounded up to nearest 5 m/s,
  *  plus 2 m/s headroom so peaks never touch the top edge.
- *  Caller should pre-slice winds/ensWind to the desired window (e.g. first 7 days) before calling.
  *  obsMax: optional max observed wind speed to include in the ceiling. */
 function _windAxisMax(winds, ensWind, obsMax = 0) {
   const base = ensWind
@@ -648,11 +647,6 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   const safeGusts = _safeClampGusts(gusts, winds);
   const cY        = 0;
   const KITE_H    = 24;                   // kite pill icon height (pills drawn on top of chart)
-  // Axis max is based on the first-7-day window only; extended-forecast data
-  // (days 7–16) is drawn but clipped to this ceiling so a distant storm does
-  // not widen the scale for the current detailed period.
-  const n7d   = times.findIndex(t => new Date(t).getTime() >= extThreshMsWind);
-  const nAx   = n7d > 0 ? n7d : n;
   const _obsWindMax = obs => obs
     ? Math.max(0, ...obs.map(ob => (ob.wind != null && isFinite(ob.wind) ? ob.wind : 0)))
     : 0;
@@ -660,11 +654,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
     _obsWindMax(window.DMI_OBS?.obs),
     _obsWindMax(window.TRAFIK_OBS),
   );
-  const maxW = _windAxisMax(
-    winds.slice(0, nAx),
-    ensWind ? { p90: ensWind.p90.slice(0, nAx) } : null,
-    obsMax
-  );
+  const maxW = _windAxisMax(winds, ensWind, obsMax);
   const wy        = v => cY + (1 - v / maxW) * WIND_H;
   const base      = wy(0);
   const wLevels   = []; for (let v = 0; v <= maxW; v += 5) wLevels.push(v);

--- a/charts.js
+++ b/charts.js
@@ -619,7 +619,7 @@ function _windAxisMax(winds, ensWind, obsMax = 0) {
   const base = ensWind
     ? Math.max(...ensWind.p90.filter(v => v != null))
     : Math.max(...winds.filter(v => v != null));
-  return Math.ceil(Math.max(base, obsMax, 5) / 5) * 5 + 2;
+  return Math.max(base, obsMax, 5) + 2;
 }
 function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h, invertedColors, totalCssW = null, xMap = null, otherModelsWind = null, otherModelsXMap = null, divXs = null) {
   // --- canvas setup ---
@@ -650,10 +650,7 @@ function drawWind(times, gusts, winds, dirs, ensWind, ensGust, times3h, winds3h,
   const _obsWindMax = obs => obs
     ? Math.max(0, ...obs.map(ob => (ob.wind != null && isFinite(ob.wind) ? ob.wind : 0)))
     : 0;
-  const obsMax = Math.max(
-    _obsWindMax(window.DMI_OBS?.obs),
-    _obsWindMax(window.TRAFIK_OBS),
-  );
+  const obsMax = _obsWindMax(window.DMI_OBS?.obs);
   const maxW = _windAxisMax(winds, ensWind, obsMax);
   const wy        = v => cY + (1 - v / maxW) * WIND_H;
   const base      = wy(0);

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -407,14 +407,13 @@ describe('_windAxisMax', () => {
     expect(ctx._windAxisMax([5, 17, 6], ensWind)).toBe(17);
   });
 
-  it('caller-sliced arrays exclude extended-forecast high values', () => {
-    // Full 10-slot p90 has a distant storm (22 m/s) in slots 7-9; caller passes
-    // only the first 7 slots so the axis stays at 17 (15+2) instead of 27 (25+2).
+  it('uses the full p90 array including high values at the end', () => {
+    // A late-forecast storm (22 m/s) in slots 7-9 should push the axis to 27 (25+2).
     const full    = [10, 12, 11, 9, 10, 11, 12, 22, 22, 22];
     const ensWind = { p90: full };
-    expect(ctx._windAxisMax([5, 5, 5], { p90: full.slice(0, 7) })).toBe(17);
-    // Confirm without slicing the storm pushes it to 27.
     expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(27);
+    // Truncated array without the storm stays at 17 (15+2).
+    expect(ctx._windAxisMax([5, 5, 5], { p90: full.slice(0, 7) })).toBe(17);
   });
 
   it('filters null values in winds array', () => {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -382,61 +382,61 @@ describe('_windAxisMax', () => {
   let ctx;
   beforeEach(() => { ctx = loadChartLogic(); });
 
-  it('returns minimum 7 (5 rounded + 2 headroom) when all winds are calm', () => {
+  it('returns minimum 7 (floor 5 + 2 headroom) when all winds are calm', () => {
     expect(ctx._windAxisMax([0, 0, 0], null)).toBe(7);
   });
 
-  it('rounds up to the nearest 5 then adds 2 m/s headroom', () => {
-    expect(ctx._windAxisMax([7, 8, 6], null)).toBe(12);
-    expect(ctx._windAxisMax([10, 11, 9], null)).toBe(17);
+  it('returns raw max + 2 with no rounding', () => {
+    expect(ctx._windAxisMax([7, 8, 6], null)).toBe(10);
+    expect(ctx._windAxisMax([10, 11, 9], null)).toBe(13);
     expect(ctx._windAxisMax([5, 5, 5], null)).toBe(7);
   });
 
   it('uses mean wind as fallback when no ensemble data', () => {
-    expect(ctx._windAxisMax([5, 8, 6], null)).toBe(12);
+    expect(ctx._windAxisMax([5, 8, 6], null)).toBe(10);
   });
 
   it('uses ensemble wind p90 as the axis ceiling when ensemble is present', () => {
     const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
-    expect(ctx._windAxisMax([5, 8, 6], ensWind)).toBe(17);
+    expect(ctx._windAxisMax([5, 8, 6], ensWind)).toBe(15);
   });
 
   it('uses p90 exclusively when ensemble is present, ignoring mean winds', () => {
-    // mean winds reach 17 but p90 only 13 → rounded ceiling is 15, +2 = 17 (not 22)
+    // mean winds reach 17 but p90 only 13 → axis is 13+2=15, not 17+2=19
     const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
-    expect(ctx._windAxisMax([5, 17, 6], ensWind)).toBe(17);
+    expect(ctx._windAxisMax([5, 17, 6], ensWind)).toBe(15);
   });
 
   it('uses the full p90 array including high values at the end', () => {
-    // A late-forecast storm (22 m/s) in slots 7-9 should push the axis to 27 (25+2).
+    // A late-forecast storm (22 m/s) in slots 7-9 → 22+2=24.
     const full    = [10, 12, 11, 9, 10, 11, 12, 22, 22, 22];
     const ensWind = { p90: full };
-    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(27);
-    // Truncated array without the storm stays at 17 (15+2).
-    expect(ctx._windAxisMax([5, 5, 5], { p90: full.slice(0, 7) })).toBe(17);
+    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(24);
+    // Truncated array without the storm → 12+2=14.
+    expect(ctx._windAxisMax([5, 5, 5], { p90: full.slice(0, 7) })).toBe(14);
   });
 
   it('filters null values in winds array', () => {
-    expect(ctx._windAxisMax([null, 12, null], null)).toBe(17);
+    expect(ctx._windAxisMax([null, 12, null], null)).toBe(14);
   });
 
   it('filters null values in ensWind.p90', () => {
     const ensWind = { p90: [null, 14, null], p10: [null, 7, null] };
-    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(17);
+    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(16);
   });
 
   it('raises axis to include obsMax when observed wind exceeds forecast', () => {
-    // forecast max 8 → rounded ceiling 10 + 2 = 12, but observed 17 → ceiling 20 + 2 = 22
-    expect(ctx._windAxisMax([6, 8, 7], null, 17)).toBe(22);
+    // forecast max 8, observed 17 → max(8,17)+2 = 19
+    expect(ctx._windAxisMax([6, 8, 7], null, 17)).toBe(19);
   });
 
   it('obsMax does not lower axis when forecast is already higher', () => {
-    expect(ctx._windAxisMax([6, 12, 7], null, 5)).toBe(17);
+    expect(ctx._windAxisMax([6, 12, 7], null, 5)).toBe(14);
   });
 
   it('obsMax=0 (default) leaves only the +2 headroom', () => {
-    expect(ctx._windAxisMax([6, 8, 7], null, 0)).toBe(12);
-    expect(ctx._windAxisMax([6, 8, 7], null)).toBe(12);
+    expect(ctx._windAxisMax([6, 8, 7], null, 0)).toBe(10);
+    expect(ctx._windAxisMax([6, 8, 7], null)).toBe(10);
   });
 });
 
@@ -533,24 +533,25 @@ describe('drawWind TRAFIK_OBS axis contribution', () => {
       getElementById: (id) => id === 'c-wind' ? canvas : makeDomEl(),
       createElement: () => makeDomEl(),
     };
-    vmCtx.window.DMI_OBS   = dmrObs  ? { obs: dmrObs }  : null;
+    vmCtx.window.DMI_OBS    = dmrObs    ? { obs: dmrObs }  : null;
     vmCtx.window.TRAFIK_OBS = trafikObs ?? null;
     vmCtx.drawWind(times, gusts, winds, dirs, null, null, null, null, false, 300, null);
-    // The wy mapping uses maxW; probe it via fillRect (background) height which equals WIND_H=130,
-    // but easiest is to call _windAxisMax directly with the expected obsMax value.
-    return vmCtx._windAxisMax(winds, null, trafikObs
-      ? Math.max(...trafikObs.map(o => o.wind ?? 0))
-      : 0);
+    // Only DMI_OBS.obs feeds obsMax; TRAFIK_OBS is not used for the axis.
+    const dmiObsMax = dmrObs
+      ? Math.max(0, ...dmrObs.map(o => (o.wind != null && isFinite(o.wind) ? o.wind : 0)))
+      : 0;
+    return vmCtx._windAxisMax(winds, null, dmiObsMax);
   }
 
-  it('TRAFIK_OBS with higher wind raises the axis above DMI_OBS alone', () => {
-    const dmiObs   = [{ t: T0, wind: 5, gust: 7 }];
+  it('TRAFIK_OBS does not affect the axis (only displayed DMI_OBS points count)', () => {
+    const dmiObs    = [{ t: T0, wind: 5, gust: 7 }];
     const trafikObs = [{ t: T0, wind: 18, gust: 20 }];
     const withTrafik    = getMaxW(dmiObs, trafikObs);
     const withoutTrafik = getMaxW(dmiObs, null);
-    expect(withTrafik).toBeGreaterThan(withoutTrafik);
-    // ceil(18/5)*5 + 2 = 22
-    expect(withTrafik).toBe(22);
+    // axis should be the same whether TRAFIK_OBS is set or not
+    expect(withTrafik).toBe(withoutTrafik);
+    // dmi wind 5 → max(5,5)+2 = 7
+    expect(withTrafik).toBe(7);
   });
 
   it('null TRAFIK_OBS is ignored gracefully', () => {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -383,60 +383,43 @@ describe('_windAxisMax', () => {
   beforeEach(() => { ctx = loadChartLogic(); });
 
   it('returns minimum 7 (floor 5 + 2 headroom) when all winds are calm', () => {
-    expect(ctx._windAxisMax([0, 0, 0], null)).toBe(7);
+    expect(ctx._windAxisMax([0, 0, 0])).toBe(7);
   });
 
-  it('returns raw max + 2 with no rounding', () => {
-    expect(ctx._windAxisMax([7, 8, 6], null)).toBe(10);
-    expect(ctx._windAxisMax([10, 11, 9], null)).toBe(13);
-    expect(ctx._windAxisMax([5, 5, 5], null)).toBe(7);
+  it('returns max wind + 2 with no rounding', () => {
+    expect(ctx._windAxisMax([7, 8, 6])).toBe(10);
+    expect(ctx._windAxisMax([10, 11, 9])).toBe(13);
+    expect(ctx._windAxisMax([5, 5, 5])).toBe(7);
   });
 
-  it('uses mean wind as fallback when no ensemble data', () => {
-    expect(ctx._windAxisMax([5, 8, 6], null)).toBe(10);
+  it('uses mean wind (the drawn line) regardless of ensemble data', () => {
+    // axis is based on the winds array only — ensemble p90 does not widen it
+    expect(ctx._windAxisMax([5, 8, 6])).toBe(10);
+    expect(ctx._windAxisMax([5, 17, 6])).toBe(19);
   });
 
-  it('uses ensemble wind p90 as the axis ceiling when ensemble is present', () => {
-    const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
-    expect(ctx._windAxisMax([5, 8, 6], ensWind)).toBe(15);
-  });
-
-  it('uses p90 exclusively when ensemble is present, ignoring mean winds', () => {
-    // mean winds reach 17 but p90 only 13 → axis is 13+2=15, not 17+2=19
-    const ensWind = { p90: [10, 13, 11], p10: [5, 6, 5] };
-    expect(ctx._windAxisMax([5, 17, 6], ensWind)).toBe(15);
-  });
-
-  it('uses the full p90 array including high values at the end', () => {
-    // A late-forecast storm (22 m/s) in slots 7-9 → 22+2=24.
-    const full    = [10, 12, 11, 9, 10, 11, 12, 22, 22, 22];
-    const ensWind = { p90: full };
-    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(24);
-    // Truncated array without the storm → 12+2=14.
-    expect(ctx._windAxisMax([5, 5, 5], { p90: full.slice(0, 7) })).toBe(14);
+  it('uses the full winds array including late-forecast high values', () => {
+    const winds = [5, 5, 5, 5, 5, 5, 5, 22, 22, 22];
+    expect(ctx._windAxisMax(winds)).toBe(24);
+    expect(ctx._windAxisMax(winds.slice(0, 7))).toBe(7);
   });
 
   it('filters null values in winds array', () => {
-    expect(ctx._windAxisMax([null, 12, null], null)).toBe(14);
-  });
-
-  it('filters null values in ensWind.p90', () => {
-    const ensWind = { p90: [null, 14, null], p10: [null, 7, null] };
-    expect(ctx._windAxisMax([5, 5, 5], ensWind)).toBe(16);
+    expect(ctx._windAxisMax([null, 12, null])).toBe(14);
   });
 
   it('raises axis to include obsMax when observed wind exceeds forecast', () => {
-    // forecast max 8, observed 17 → max(8,17)+2 = 19
-    expect(ctx._windAxisMax([6, 8, 7], null, 17)).toBe(19);
+    // mean forecast max 8, observed 17 → max(8,17)+2 = 19
+    expect(ctx._windAxisMax([6, 8, 7], 17)).toBe(19);
   });
 
   it('obsMax does not lower axis when forecast is already higher', () => {
-    expect(ctx._windAxisMax([6, 12, 7], null, 5)).toBe(14);
+    expect(ctx._windAxisMax([6, 12, 7], 5)).toBe(14);
   });
 
   it('obsMax=0 (default) leaves only the +2 headroom', () => {
-    expect(ctx._windAxisMax([6, 8, 7], null, 0)).toBe(10);
-    expect(ctx._windAxisMax([6, 8, 7], null)).toBe(10);
+    expect(ctx._windAxisMax([6, 8, 7], 0)).toBe(10);
+    expect(ctx._windAxisMax([6, 8, 7])).toBe(10);
   });
 });
 
@@ -540,7 +523,7 @@ describe('drawWind TRAFIK_OBS axis contribution', () => {
     const dmiObsMax = dmrObs
       ? Math.max(0, ...dmrObs.map(o => (o.wind != null && isFinite(o.wind) ? o.wind : 0)))
       : 0;
-    return vmCtx._windAxisMax(winds, null, dmiObsMax);
+    return vmCtx._windAxisMax(winds, dmiObsMax);
   }
 
   it('TRAFIK_OBS does not affect the axis (only displayed DMI_OBS points count)', () => {


### PR DESCRIPTION
## Summary

- Axis now spans the full 16-day forecast, not just the first 7 days
- Axis is sized to the **mean wind line** (p50/deterministic), not ensemble p90 — prevents the axis from inflating to gust-level values under uncertain conditions
- Observed wind (`ob.wind`, not `ob.gust`) from the currently displayed station (`DMI_OBS`) is included in the max
- No rounding to nearest 5 — raw `max(mean wind, observed wind, 5) + 2` m/s

## Test plan

- [ ] Check axis height on a calm day — should be close to mean wind + 2, not inflated by ensemble bands
- [ ] Check axis height on a stormy day with high ensemble spread — axis should follow the mean wind line, with the p90 band potentially clipped at the top
- [ ] Verify observed wind dots are never clipped below the axis top
- [ ] Verify gust dashes can extend above the axis (clipped at canvas edge), axis not widened for them

https://claude.ai/code/session_01F6r4KbyKieHiZzYFZ53d26

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6r4KbyKieHiZzYFZ53d26)_