### PR TITLE
Migrate forecast history to SQLite; add stratified bias by speed+bearing

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -990,17 +990,53 @@ function _bearingBin(d) {
 
   /**
    * Read pre-computed forecast bias for a station from window.OBS_HISTORY.
-   * When current obs wind/dir are supplied, tries the stratified cell first.
-   * Returns { bias, n, stratified } or null when absent / insufficient data.
+   * fcstWind / fcstDir are the current Open-Meteo forecast at that station —
+   * used to select the relevant (speed_bin × bearing_bin) bias cell.
+   *
+   * Lookup order:
+   *   1. Exact (speed_bin, bearing_bin) cell
+   *   2. IDW interpolation across all populated cells in the same station
+   *   3. Scalar mean fallback (no forecast conditions available or no strat data)
+   *
+   * Returns { bias, n, stratified, interpolated } or null.
    */
-  function _stationBias(key, obsWind, obsDir) {
+  function _stationBias(key, fcstWind, fcstDir) {
     const b = window.OBS_HISTORY?.[key]?.bias;
     if (!b || b.n == null || b.wind == null) return null;
-    if (b.strat && obsWind != null && obsDir != null) {
-      const cell = b.strat[`${_speedBin(obsWind)}_${_bearingBin(obsDir)}`];
-      if (cell) return { bias: cell.mean, n: cell.n, stratified: true };
+
+    if (b.strat && fcstWind != null && fcstDir != null) {
+      const tSpd = _speedBin(fcstWind);
+      const tBrg = _bearingBin(fcstDir);
+
+      // 1. Exact match
+      const exact = b.strat[`${tSpd}_${tBrg}`];
+      if (exact) return { bias: exact.mean, n: exact.n, stratified: true, interpolated: false };
+
+      // 2. IDW interpolation across all populated cells
+      const SPEED_BINS   = [0, 4, 8, 12];
+      const BEARING_BINS = [0, 45, 90, 135, 180, 225, 270, 315];
+      const tSpdIdx = SPEED_BINS.indexOf(tSpd);
+      const tBrgIdx = BEARING_BINS.indexOf(tBrg);
+
+      let wSum = 0, bSum = 0, nMin = Infinity;
+      for (const [ck, cv] of Object.entries(b.strat)) {
+        const [cs, cb] = ck.split('_').map(Number);
+        const sSteps = Math.abs(SPEED_BINS.indexOf(cs) - tSpdIdx);
+        let bSteps = Math.abs(BEARING_BINS.indexOf(cb) - tBrgIdx);
+        if (bSteps > 4) bSteps = 8 - bSteps;  // circular wrap
+        const dist = Math.sqrt(sSteps * sSteps + bSteps * bSteps);
+        const w = 1 / (dist || 1e-9);
+        wSum += w;
+        bSum += w * cv.mean;
+        nMin = Math.min(nMin, cv.n);
+      }
+      if (wSum > 0) {
+        return { bias: bSum / wSum, n: nMin, stratified: true, interpolated: true };
+      }
     }
-    return { bias: b.wind, n: b.n, stratified: false };
+
+    // 3. Scalar fallback
+    return { bias: b.wind, n: b.n, stratified: false, interpolated: false };
   }
 
   const DIR_DEG = {
@@ -1124,6 +1160,10 @@ function _bearingBin(d) {
           });
 
           const obsTime = new Date(latest.t);
+          const nowH = new Date().getUTCHours();
+          const fcstArr = station.fcst;
+          const fcstEntry = fcstArr?.find(f => f.h === nowH) ?? fcstArr?.[fcstArr.length - 1] ?? null;
+
           const sObj = {
             key,
             name:         station.name,
@@ -1134,6 +1174,7 @@ function _bearingBin(d) {
             obsTime,
             obsHistory:   station.obs,
             latest:       { wind: latest.wind, gust: latest.gust ?? null, dir: latest.dir ?? null, time: latest.t },
+            fcst:         fcstEntry ? { wind: fcstEntry.wind ?? null, dir: fcstEntry.dir ?? null } : null,
           };
 
           const popupEl = _buildStationPopupEl(sObj);
@@ -1187,12 +1228,14 @@ function _bearingBin(d) {
             const biasEl = popupEl.querySelector('.dmi-bias-row');
             if (biasEl && biasEl.dataset.loaded !== '1') {
               biasEl.dataset.loaded = '1';
-              const b = _stationBias(key, sObj.latest.wind, sObj.latest.dir);
+              const b = _stationBias(key, sObj.fcst?.wind, sObj.fcst?.dir);
               if (b) {
                 const sign    = b.bias >= 0 ? '+' : '';
                 const absB    = Math.abs(b.bias);
                 const biasCol = absB > 2 ? '#e06020' : absB > 1 ? '#e0a020' : '#8899aa';
-                const label   = b.stratified ? 'Model bias (current)' : 'Model bias';
+                const label   = !b.stratified  ? 'Model bias'
+                              : b.interpolated ? 'Model bias (approx)'
+                              :                  'Model bias (current)';
                 biasEl.innerHTML =
                   `<span style="color:#aaa;font-size:10px">${label}&nbsp;</span>` +
                   `<span style="color:${biasCol};font-size:10px;font-weight:600">${sign}${b.bias.toFixed(1)}&nbsp;m/s</span>` +

--- a/radar.js
+++ b/radar.js
@@ -100,6 +100,17 @@ function _buildKiteSpotIssueUrl({ lat, lon, name, dirs }) {
 }
 window._buildKiteSpotIssueUrl = _buildKiteSpotIssueUrl;
 
+function _speedBin(w) {
+  if (w < 4)  return 0;
+  if (w < 8)  return 4;
+  if (w < 12) return 8;
+  return 12;
+}
+
+function _bearingBin(d) {
+  return Math.floor(d / 45) * 45 % 360;
+}
+
 (function () {
   // Leaflet is loaded from CDN; bail out gracefully if it failed (offline / blocked).
   if (typeof L === 'undefined') {
@@ -978,13 +989,18 @@ window._buildKiteSpotIssueUrl = _buildKiteSpotIssueUrl;
   }
 
   /**
-   * Read pre-computed forecast bias for a station key from window.OBS_HISTORY.
-   * Returns { bias: number, n: number } or null when absent / insufficient data.
+   * Read pre-computed forecast bias for a station from window.OBS_HISTORY.
+   * When current obs wind/dir are supplied, tries the stratified cell first.
+   * Returns { bias, n, stratified } or null when absent / insufficient data.
    */
-  function _stationBias(key) {
+  function _stationBias(key, obsWind, obsDir) {
     const b = window.OBS_HISTORY?.[key]?.bias;
     if (!b || b.n == null || b.wind == null) return null;
-    return { bias: b.wind, n: b.n };
+    if (b.strat && obsWind != null && obsDir != null) {
+      const cell = b.strat[`${_speedBin(obsWind)}_${_bearingBin(obsDir)}`];
+      if (cell) return { bias: cell.mean, n: cell.n, stratified: true };
+    }
+    return { bias: b.wind, n: b.n, stratified: false };
   }
 
   const DIR_DEG = {
@@ -1171,13 +1187,14 @@ window._buildKiteSpotIssueUrl = _buildKiteSpotIssueUrl;
             const biasEl = popupEl.querySelector('.dmi-bias-row');
             if (biasEl && biasEl.dataset.loaded !== '1') {
               biasEl.dataset.loaded = '1';
-              const b = _stationBias(key);
+              const b = _stationBias(key, sObj.latest.wind, sObj.latest.dir);
               if (b) {
                 const sign    = b.bias >= 0 ? '+' : '';
                 const absB    = Math.abs(b.bias);
                 const biasCol = absB > 2 ? '#e06020' : absB > 1 ? '#e0a020' : '#8899aa';
+                const label   = b.stratified ? 'Model bias (current)' : 'Model bias';
                 biasEl.innerHTML =
-                  `<span style="color:#aaa;font-size:10px">Model bias&nbsp;</span>` +
+                  `<span style="color:#aaa;font-size:10px">${label}&nbsp;</span>` +
                   `<span style="color:${biasCol};font-size:10px;font-weight:600">${sign}${b.bias.toFixed(1)}&nbsp;m/s</span>` +
                   `<span style="color:#aaa;font-size:10px">&nbsp;·&nbsp;${b.n}h</span>`;
               } else {

--- a/scripts/fetch-ninjo.py
+++ b/scripts/fetch-ninjo.py
@@ -12,7 +12,13 @@ Pushes one gzip-compressed JSON file to gh-pages:
         "ninjo:<stationId>": {
           "name": "...", "lat": 55.6, "lon": 12.6, "source": "ninjo",
           "obs":  [{"t": <unix_ms>, "wind": 5.1, "gust": 7.2, "dir": 270}, ...],
-          "bias": {"wind": 1.3, "n": 84}   ← added daily, absent until day 1
+          "bias": {
+            "wind": 1.3, "n": 84,           ← scalar mean, added daily
+            "strat": {                       ← optional, present after ~30 days
+              "4_270": {"mean": 1.1, "n": 18},   key = "<speed_bin>_<bearing_bin>"
+              ...
+            }
+          }
         },
         "trafikkort:<featureId>": {
           "name": "Trafikkort 1018", "lat": ..., "lon": ..., "source": "trafikkort",
@@ -21,12 +27,10 @@ Pushes one gzip-compressed JSON file to gh-pages:
       }
 
 Local state (never pushed to gh-pages):
-  obs-history-local.json.gz   — written next to this file after every obs push
-  fcst-history-local.json.gz  — written after every daily forecast ingest
-
-  Both files are restored on startup (disk → gh-pages fallback → empty dict),
-  so a crash or AppDaemon restart loses at most one 10-min obs cycle and never
-  loses the 7-day forecast window needed for bias computation.
+  obs-history-local.json   — written next to this file after every obs push
+  fcst-history.db          — SQLite database; 30-day rolling window of hourly
+                             forecast/obs pairs per station for bias computation.
+                             Created automatically on first run; never pushed.
 
 Installation (Home Assistant AppDaemon add-on — a0d7b954):
   All paths are under /root/addon_configs/a0d7b954_appdaemon/
@@ -59,6 +63,7 @@ import base64
 import gzip
 import json
 import math
+import sqlite3
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 from pathlib import Path
@@ -76,7 +81,8 @@ OPEN_METEO  = 'https://api.open-meteo.com/v1/forecast'
 
 # Rolling-window settings
 OBS_WINDOW_H  = 24   # hours of obs to keep per station
-FCST_WINDOW_D = 7    # days of forecast history to keep
+FCST_WINDOW_D = 30   # days of forecast history to keep in SQLite
+STRAT_MIN_N   = 6    # minimum samples for a stratified bias cell to be reported
 
 # Open-Meteo batch: stations per request (comma-separated lat/lon)
 FORECAST_BATCH = 50
@@ -85,13 +91,13 @@ FORECAST_BATCH = 50
 RAW_BASE = 'https://raw.githubusercontent.com/ncvangilse/vejr/data'
 
 # Local state files — persisted next to the app file so crashes / restarts
-# don't lose accumulated history.  fcst-history is never pushed to the data branch
-# so local persistence is the only way to survive a restart.
+# don't lose accumulated history.  The forecast DB is never pushed to gh-pages;
+# local disk is the only persistence.
 _APP_DIR   = Path(__file__).parent
 STATE_FILES = {
-    'obs_history':  _APP_DIR / 'obs-history-local.json',
-    'fcst_history': _APP_DIR / 'fcst-history-local.json',
+    'obs_history': _APP_DIR / 'obs-history-local.json',
 }
+_FCST_DB = _APP_DIR / 'fcst-history.db'
 
 # Cardinal direction → degrees (matches radar.js DIR_DEG)
 DIR_DEG = {
@@ -103,6 +109,41 @@ DIR_DEG = {
 
 
 # ── Pure helpers ───────────────────────────────────────────────────────────────
+
+def _speed_bin(w):
+    """Return the lower edge of the 4 m/s speed bin containing w."""
+    if w < 4:  return 0
+    if w < 8:  return 4
+    if w < 12: return 8
+    return 12
+
+
+def _bearing_bin(d):
+    """Return the start of the 45° bearing sector containing d (0–359°)."""
+    return int(d // 45) * 45 % 360
+
+
+def _open_fcst_db():
+    """Open (or create) the SQLite forecast-history database."""
+    conn = sqlite3.connect(str(_FCST_DB), check_same_thread=False)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS forecast_obs (
+            station_key TEXT    NOT NULL,
+            date        TEXT    NOT NULL,
+            hour        INTEGER NOT NULL,
+            fcst_wind   REAL,
+            fcst_dir    REAL,
+            obs_wind    REAL,
+            PRIMARY KEY (station_key, date, hour)
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_station_date "
+        "ON forecast_obs (station_key, date)"
+    )
+    conn.commit()
+    return conn
+
 
 _COPENHAGEN = ZoneInfo('Europe/Copenhagen')
 
@@ -185,10 +226,10 @@ class FetchNinjo(hass.Hass):
     BRANCH = 'data'
 
     def initialize(self):
-        self.token        = self.args['github_token']
-        self.obs_history  = None   # dict; loaded lazily on first run
-        self.fcst_history = None   # dict; loaded lazily on first forecast run
-        self._lock        = asyncio.Lock()
+        self.token       = self.args['github_token']
+        self.obs_history = None          # dict; loaded lazily on first run
+        self.fcst_conn   = _open_fcst_db()  # SQLite connection; persists to disk
+        self._lock       = asyncio.Lock()
 
         # Obs ingestion: every 10 minutes, starting immediately
         self.run_every(self._ingest_obs_cb, 'now', 10 * 60)
@@ -298,41 +339,36 @@ class FetchNinjo(hass.Hass):
           1. Local disk (fast, always preferred — survives crashes with no network)
           2. gh-pages raw URL for obs-history (first deploy / disk wiped)
           3. Empty dict (fresh start)
-        fcst_history is never on gh-pages, so local disk or empty are the only options.
+        fcst_conn is a SQLite DB opened in initialize(); no load needed here.
         """
-        for attr, filename in [
-            ('obs_history',  'obs-history.json.gz'),
-            ('fcst_history', None),   # not on gh-pages
-        ]:
-            if getattr(self, attr) is not None:
-                continue   # already loaded (shouldn't happen, but be safe)
+        if self.obs_history is not None:
+            return   # already loaded
 
-            # 1. Local disk
-            if self._load_local(attr):
-                continue
+        # 1. Local disk
+        if self._load_local('obs_history'):
+            return
 
-            # 2. gh-pages remote (obs-history only)
-            if filename:
-                url = f'{RAW_BASE}/{filename}'
-                try:
-                    async with session.get(
-                        url, timeout=aiohttp.ClientTimeout(total=30)
-                    ) as r:
-                        if r.status == 200:
-                            raw    = await r.read()
-                            loaded = json.loads(gzip.decompress(raw))
-                            setattr(self, attr, loaded)
-                            self.log(f'Bootstrapped {filename} from gh-pages: {len(loaded)} stations')
-                            self._save_local(attr)   # write to disk immediately
-                            continue
-                        self.log(f'{filename} not on gh-pages (HTTP {r.status}) — starting fresh')
-                except Exception as e:
-                    self.log(f'Could not fetch {filename} from gh-pages: {e}',
-                             level='WARNING')
+        # 2. gh-pages remote
+        url = f'{RAW_BASE}/obs-history.json.gz'
+        try:
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=30)
+            ) as r:
+                if r.status == 200:
+                    raw    = await r.read()
+                    loaded = json.loads(gzip.decompress(raw))
+                    self.obs_history = loaded
+                    self.log(f'Bootstrapped obs-history.json.gz from gh-pages: {len(loaded)} stations')
+                    self._save_local('obs_history')
+                    return
+                self.log(f'obs-history.json.gz not on gh-pages (HTTP {r.status}) — starting fresh')
+        except Exception as e:
+            self.log(f'Could not fetch obs-history.json.gz from gh-pages: {e}',
+                     level='WARNING')
 
-            # 3. Fresh start
-            setattr(self, attr, {})
-            self.log(f'{attr} initialised as empty dict')
+        # 3. Fresh start
+        self.obs_history = {}
+        self.log('obs_history initialised as empty dict')
 
     # ── Generic JSON fetch ─────────────────────────────────────────────────────
 
@@ -415,38 +451,60 @@ class FetchNinjo(hass.Hass):
     def _compute_bias(self):
         """
         Compute forecast bias (mean forecast − obs) for every station over the
-        7-day rolling window.  Updates obs_history[key]['bias'] in-place.
+        30-day rolling window stored in SQLite.  Produces both a scalar mean
+        and a stratified table keyed by (speed_bin, bearing_bin).
+        Updates obs_history[key]['bias'] in-place.
         Returns the number of stations that received a bias value.
         """
-        all_diffs = []
-        for key, fh_entry in self.fcst_history.items():
-            for day in fh_entry.get('days', {}).values():
-                fcst = day.get('forecast',   [])
-                obs  = day.get('obs_hourly', [])
-                if not fcst or not obs:
-                    continue
-                df_f = pd.DataFrame(fcst)[['h', 'wind']].rename(columns={'wind': 'f_wind'})
-                df_o = pd.DataFrame(obs) [['h', 'wind']].rename(columns={'wind': 'o_wind'})
-                merged = df_f.merge(df_o, on='h').dropna(subset=['f_wind', 'o_wind'])
-                if merged.empty:
-                    continue
-                merged['key'] = key
-                all_diffs.append(merged[['key', 'f_wind', 'o_wind']])
+        df = pd.read_sql(
+            "SELECT station_key, fcst_wind, fcst_dir, obs_wind "
+            "FROM forecast_obs "
+            "WHERE fcst_wind IS NOT NULL AND obs_wind IS NOT NULL",
+            self.fcst_conn,
+        )
+        if df.empty:
+            for key in self.obs_history:
+                self.obs_history[key].pop('bias', None)
+            return 0
 
-        stats = {}
-        if all_diffs:
-            combined = pd.concat(all_diffs, ignore_index=True)
-            combined['diff'] = combined['f_wind'] - combined['o_wind']
-            agg = combined.groupby('key')['diff'].agg(['mean', 'count'])
-            stats = agg[agg['count'] >= 6].to_dict('index')
+        df['error'] = df['fcst_wind'] - df['obs_wind']
+
+        # Scalar bias per station
+        scalar = (
+            df.groupby('station_key')['error']
+              .agg(['mean', 'count'])
+              .query(f'count >= {STRAT_MIN_N}')
+              .to_dict('index')
+        )
+
+        # Stratified bias by (speed_bin, bearing_bin)
+        df['speed_bin']   = df['fcst_wind'].apply(_speed_bin)
+        df['bearing_bin'] = df['fcst_dir'].apply(_bearing_bin)
+        strat_rows = (
+            df.groupby(['station_key', 'speed_bin', 'bearing_bin'])['error']
+              .agg(['mean', 'count'])
+              .reset_index()
+              .query(f'count >= {STRAT_MIN_N}')
+        )
+        strat_by_key = {}
+        for _, row in strat_rows.iterrows():
+            k    = row['station_key']
+            cell = f"{int(row['speed_bin'])}_{int(row['bearing_bin'])}"
+            strat_by_key.setdefault(k, {})[cell] = {
+                'mean': round(float(row['mean']), 2),
+                'n':    int(row['count']),
+            }
 
         n_bias = 0
         for key in self.obs_history:
-            if key in stats:
-                self.obs_history[key]['bias'] = {
-                    'wind': round(float(stats[key]['mean']), 2),
-                    'n':    int(stats[key]['count']),
+            if key in scalar:
+                bias = {
+                    'wind': round(float(scalar[key]['mean']), 2),
+                    'n':    int(scalar[key]['count']),
                 }
+                if key in strat_by_key:
+                    bias['strat'] = strat_by_key[key]
+                self.obs_history[key]['bias'] = bias
                 n_bias += 1
             else:
                 self.obs_history[key].pop('bias', None)
@@ -522,7 +580,7 @@ class FetchNinjo(hass.Hass):
             }
 
             async with aiohttp.ClientSession() as session:
-                if self.obs_history is None or self.fcst_history is None:
+                if self.obs_history is None:
                     await self._load_state(session)
                 sha_map = await self._get_sha_map(session, gh_headers)
 
@@ -570,38 +628,63 @@ class FetchNinjo(hass.Hass):
                         df_f = df_f[df_f['date'] >= cutoff_str][['date', 'h', 'wind', 'dir']]
                         df_f['wind'] = pd.to_numeric(df_f['wind'], errors='coerce').round(2)
                         df_f['dir']  = pd.to_numeric(df_f['dir'],  errors='coerce').round(1)
+                        clean = df_f.dropna(subset=['wind'])
 
-                        days = self.fcst_history.setdefault(key, {'days': {}})['days']
-                        for date, grp in df_f.groupby('date'):
-                            clean = grp[['h', 'wind', 'dir']].dropna(subset=['wind'])
-                            days.setdefault(date, {'forecast': [], 'obs_hourly': []})
-                            days[date]['forecast'] = [
-                                {k: v for k, v in rec.items() if pd.notna(v)}
-                                for rec in clean.to_dict('records')
-                            ]
+                        fcst_rows = [
+                            (
+                                key,
+                                str(row['date']),
+                                int(row['h']),
+                                float(row['wind']),
+                                float(row['dir']) if pd.notna(row['dir']) else None,
+                            )
+                            for _, row in clean.iterrows()
+                        ]
+                        self.fcst_conn.executemany("""
+                            INSERT INTO forecast_obs
+                                (station_key, date, hour, fcst_wind, fcst_dir)
+                            VALUES (?,?,?,?,?)
+                            ON CONFLICT(station_key, date, hour)
+                            DO UPDATE SET
+                                fcst_wind = excluded.fcst_wind,
+                                fcst_dir  = excluded.fcst_dir
+                        """, fcst_rows)
 
                     if batch_start + FORECAST_BATCH < len(stations):
                         await asyncio.sleep(1)
 
-                # ── Attach yesterday's hourly obs, prune, compute bias ──────────
-                for key, info in self.obs_history.items():
-                    days = self.fcst_history.setdefault(key, {'days': {}})['days']
-                    days.setdefault(yesterday_str, {'forecast': [], 'obs_hourly': []})
-                    days[yesterday_str]['obs_hourly'] = _resample_hourly(
-                        info.get('obs', []), yesterday_str)
+                self.fcst_conn.commit()
 
-                for key in self.fcst_history:
-                    self.fcst_history[key]['days'] = {
-                        d: v for d, v in self.fcst_history[key]['days'].items()
-                        if d >= cutoff_str
-                    }
+                # ── Attach yesterday's hourly obs ──────────────────────────────
+                obs_rows = []
+                for key, info in self.obs_history.items():
+                    for entry in _resample_hourly(info.get('obs', []), yesterday_str):
+                        if 'wind' in entry:
+                            obs_rows.append((
+                                entry['wind'], key, yesterday_str, entry['h'],
+                            ))
+                self.fcst_conn.executemany(
+                    "UPDATE forecast_obs SET obs_wind=? "
+                    "WHERE station_key=? AND date=? AND hour=?",
+                    obs_rows,
+                )
+
+                # ── Prune old rows ─────────────────────────────────────────────
+                self.fcst_conn.execute(
+                    "DELETE FROM forecast_obs WHERE date < ?", (cutoff_str,)
+                )
+                self.fcst_conn.commit()
 
                 n_bias = self._compute_bias()
-                self.log(f'{ts}  Forecast history: {len(self.fcst_history)} stations · bias for {n_bias}')
+                row_count = self.fcst_conn.execute(
+                    "SELECT COUNT(*) FROM forecast_obs"
+                ).fetchone()[0]
+                self.log(
+                    f'{ts}  Forecast history: {row_count} rows in DB · bias for {n_bias}'
+                )
 
                 await self._push_gz(
                     session, gh_headers, sha_map,
                     'obs-history.json.gz', self.obs_history, ts,
                 )
                 self._save_local('obs_history')
-                self._save_local('fcst_history')

--- a/scripts/fetch-ninjo.py
+++ b/scripts/fetch-ninjo.py
@@ -81,7 +81,7 @@ OPEN_METEO  = 'https://api.open-meteo.com/v1/forecast'
 
 # Rolling-window settings
 OBS_WINDOW_H  = 24   # hours of obs to keep per station
-FCST_WINDOW_D = 30   # days of forecast history to keep in SQLite
+FCST_WINDOW_D = 365  # days of forecast history to keep in SQLite
 STRAT_MIN_N   = 6    # minimum samples for a stratified bias cell to be reported
 
 # Open-Meteo batch: stations per request (comma-separated lat/lon)
@@ -584,6 +584,7 @@ class FetchNinjo(hass.Hass):
                     await self._load_state(session)
                 sha_map = await self._get_sha_map(session, gh_headers)
 
+                today_str     = datetime.now(timezone.utc).strftime('%Y-%m-%d')
                 yesterday_str = (datetime.now(timezone.utc) - timedelta(days=1)).strftime('%Y-%m-%d')
                 cutoff_str    = (datetime.now(timezone.utc) - timedelta(days=FCST_WINDOW_D)).strftime('%Y-%m-%d')
 
@@ -649,6 +650,18 @@ class FetchNinjo(hass.Hass):
                                 fcst_wind = excluded.fcst_wind,
                                 fcst_dir  = excluded.fcst_dir
                         """, fcst_rows)
+
+                        # Store today's hourly forecast per station in obs_history so
+                        # the JS popup can use forecast conditions (not obs) for bias lookup.
+                        today_fcst = clean[clean['date'] == today_str][['h', 'wind', 'dir']]
+                        self.obs_history.setdefault(key, {})['fcst'] = [
+                            {
+                                'h':    int(row['h']),
+                                'wind': round(float(row['wind']), 2),
+                                **({'dir': round(float(row['dir']), 1)} if pd.notna(row['dir']) else {}),
+                            }
+                            for _, row in today_fcst.iterrows()
+                        ]
 
                     if batch_start + FORECAST_BATCH < len(stations):
                         await asyncio.sleep(1)

--- a/scripts/test_fetch_ninjo.py
+++ b/scripts/test_fetch_ninjo.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 """Unit tests for pure helpers in fetch-ninjo.py."""
+import os
+import sqlite3
+import tempfile
 import unittest
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
@@ -112,6 +115,139 @@ class TestTrafikkDirFilter(unittest.TestCase):
         wind_dir = 'N'
         self.assertIsNotNone(wind_speed)
         self.assertIsNotNone(_map_dir(wind_dir))
+
+
+# ── Speed and bearing bin helpers ─────────────────────────────────────────────
+# Replicated from fetch-ninjo.py to test independently of AppDaemon imports.
+
+def _speed_bin(w):
+    if w < 4:  return 0
+    if w < 8:  return 4
+    if w < 12: return 8
+    return 12
+
+
+def _bearing_bin(d):
+    return int(d // 45) * 45 % 360
+
+
+class TestSpeedBin(unittest.TestCase):
+    def test_zero(self):          self.assertEqual(_speed_bin(0),    0)
+    def test_below_4(self):       self.assertEqual(_speed_bin(3.9),  0)
+    def test_at_4(self):          self.assertEqual(_speed_bin(4),    4)
+    def test_mid_bin_4_8(self):   self.assertEqual(_speed_bin(7.9),  4)
+    def test_at_8(self):          self.assertEqual(_speed_bin(8),    8)
+    def test_mid_bin_8_12(self):  self.assertEqual(_speed_bin(11.9), 8)
+    def test_at_12(self):         self.assertEqual(_speed_bin(12),   12)
+    def test_above_12(self):      self.assertEqual(_speed_bin(20),   12)
+
+
+class TestBearingBin(unittest.TestCase):
+    def test_north(self):           self.assertEqual(_bearing_bin(0),   0)
+    def test_just_below_45(self):   self.assertEqual(_bearing_bin(44),  0)
+    def test_at_45(self):           self.assertEqual(_bearing_bin(45),  45)
+    def test_ne_mid(self):          self.assertEqual(_bearing_bin(60),  45)
+    def test_south(self):           self.assertEqual(_bearing_bin(180), 180)
+    def test_west(self):            self.assertEqual(_bearing_bin(270), 270)
+    def test_exactly_315(self):     self.assertEqual(_bearing_bin(315), 315)
+    def test_near_360(self):        self.assertEqual(_bearing_bin(359), 315)
+
+
+class TestFcstDbSchema(unittest.TestCase):
+    """Verify that the SQLite schema and index are created correctly."""
+
+    def _create_db(self, path):
+        conn = sqlite3.connect(path)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS forecast_obs (
+                station_key TEXT    NOT NULL,
+                date        TEXT    NOT NULL,
+                hour        INTEGER NOT NULL,
+                fcst_wind   REAL,
+                fcst_dir    REAL,
+                obs_wind    REAL,
+                PRIMARY KEY (station_key, date, hour)
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_station_date "
+            "ON forecast_obs (station_key, date)"
+        )
+        conn.commit()
+        return conn
+
+    def test_creates_table(self):
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            path = f.name
+        try:
+            conn = self._create_db(path)
+            tables = [r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()]
+            self.assertIn('forecast_obs', tables)
+            conn.close()
+        finally:
+            os.unlink(path)
+
+    def test_creates_index(self):
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            path = f.name
+        try:
+            conn = self._create_db(path)
+            indexes = [r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()]
+            self.assertIn('idx_station_date', indexes)
+            conn.close()
+        finally:
+            os.unlink(path)
+
+    def test_upsert_forecast_preserves_obs_wind(self):
+        conn = sqlite3.connect(':memory:')
+        conn.execute("""
+            CREATE TABLE forecast_obs (
+                station_key TEXT, date TEXT, hour INTEGER,
+                fcst_wind REAL, fcst_dir REAL, obs_wind REAL,
+                PRIMARY KEY (station_key, date, hour)
+            )
+        """)
+        # Insert forecast row with no obs
+        conn.execute(
+            "INSERT INTO forecast_obs (station_key,date,hour,fcst_wind,fcst_dir) "
+            "VALUES ('k1','2026-04-25',10,5.0,270.0)"
+        )
+        # Add obs separately
+        conn.execute(
+            "UPDATE forecast_obs SET obs_wind=4.5 "
+            "WHERE station_key='k1' AND date='2026-04-25' AND hour=10"
+        )
+        # Re-upsert forecast should not clear obs_wind
+        conn.execute("""
+            INSERT INTO forecast_obs (station_key,date,hour,fcst_wind,fcst_dir)
+            VALUES ('k1','2026-04-25',10,5.1,272.0)
+            ON CONFLICT(station_key,date,hour)
+            DO UPDATE SET fcst_wind=excluded.fcst_wind, fcst_dir=excluded.fcst_dir
+        """)
+        row = conn.execute(
+            "SELECT fcst_wind, obs_wind FROM forecast_obs"
+        ).fetchone()
+        self.assertAlmostEqual(row[0], 5.1)   # updated forecast
+        self.assertAlmostEqual(row[1], 4.5)   # obs preserved
+        conn.close()
+
+    def test_primary_key_uniqueness(self):
+        conn = sqlite3.connect(':memory:')
+        conn.execute("""
+            CREATE TABLE forecast_obs (
+                station_key TEXT, date TEXT, hour INTEGER,
+                fcst_wind REAL, fcst_dir REAL, obs_wind REAL,
+                PRIMARY KEY (station_key, date, hour)
+            )
+        """)
+        conn.execute("INSERT INTO forecast_obs VALUES ('k1','2026-04-25',10,5.0,270.0,4.5)")
+        with self.assertRaises(sqlite3.IntegrityError):
+            conn.execute("INSERT INTO forecast_obs VALUES ('k1','2026-04-25',10,6.0,280.0,NULL)")
+        conn.close()
 
 
 if __name__ == '__main__':

--- a/tests/radar.test.js
+++ b/tests/radar.test.js
@@ -4,7 +4,8 @@ import { loadScripts } from './helpers/loader.js';
 // radar.js is an IIFE that requires Leaflet (L). Without it the IIFE returns
 // early, but module-level helpers defined before the IIFE are still available.
 const ctx = loadScripts('radar.js');
-const { _parseNominatimPlace, _nominatimHasLocalDetail, _clampMenuPos, _buildProposeNameUrl } = ctx;
+const { _parseNominatimPlace, _nominatimHasLocalDetail, _clampMenuPos, _buildProposeNameUrl,
+        _speedBin, _bearingBin } = ctx;
 
 describe('OBS_HISTORY_URL', () => {
   it('points to raw.githubusercontent.com data branch', () => {
@@ -252,4 +253,26 @@ describe('fetchStationNames', () => {
     await ctx.window.fetchStationNames();
     expect(capturedUrl).toBe('station-names.json');
   });
+});
+
+describe('_speedBin', () => {
+  it('bins 0 to 0',    () => expect(_speedBin(0)).toBe(0));
+  it('bins 3.9 to 0',  () => expect(_speedBin(3.9)).toBe(0));
+  it('bins 4 to 4',    () => expect(_speedBin(4)).toBe(4));
+  it('bins 7.9 to 4',  () => expect(_speedBin(7.9)).toBe(4));
+  it('bins 8 to 8',    () => expect(_speedBin(8)).toBe(8));
+  it('bins 11.9 to 8', () => expect(_speedBin(11.9)).toBe(8));
+  it('bins 12 to 12',  () => expect(_speedBin(12)).toBe(12));
+  it('bins 20 to 12',  () => expect(_speedBin(20)).toBe(12));
+});
+
+describe('_bearingBin', () => {
+  it('0° → 0',     () => expect(_bearingBin(0)).toBe(0));
+  it('44° → 0',    () => expect(_bearingBin(44)).toBe(0));
+  it('45° → 45',   () => expect(_bearingBin(45)).toBe(45));
+  it('60° → 45',   () => expect(_bearingBin(60)).toBe(45));
+  it('180° → 180', () => expect(_bearingBin(180)).toBe(180));
+  it('270° → 270', () => expect(_bearingBin(270)).toBe(270));
+  it('315° → 315', () => expect(_bearingBin(315)).toBe(315));
+  it('359° → 315', () => expect(_bearingBin(359)).toBe(315));
 });


### PR DESCRIPTION
Replaces fcst-history-local.json (7-day JSON rewrite) with a SQLite
database (fcst-history.db) for extended 30-day retention and efficient
incremental append+prune.  Stratified bias cells keyed by
(speed_bin × bearing_bin) are computed alongside the existing scalar mean
and embedded in obs-history.json.gz under bias.strat.  The station popup
in radar.js now shows a context-aware "Model bias (current)" label when a
matching stratified cell exists for the current observed wind conditions,
falling back to the scalar mean otherwise.

https://claude.ai/code/session_01NDcYAxacEEikbESVX23AhK