### PR TITLE
Add service worker tests and exclude raw.githubusercontent.com from caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -38,14 +38,16 @@ self.addEventListener('fetch', event => {
   // Never intercept non-GET requests (POST etc.) — Cache API doesn't support them
   if (event.request.method !== 'GET') return;
 
-  // Network-only: weather APIs, radar, geocoding, and Overpass (must always be live)
+  // Network-only: weather APIs, radar, geocoding, Overpass, and dynamic data files
+  // (raw.githubusercontent.com hosts obs-history.json.gz which the RPi updates every 10 min)
   if (
     url.hostname.includes('dmi.dk') ||
     url.hostname.includes('open-meteo.com') ||
     url.hostname.includes('nominatim') ||
     url.hostname.includes('rainviewer.com') ||
     url.hostname.includes('overpass-api.de') ||
-    url.hostname.includes('overpass.kumi.systems')
+    url.hostname.includes('overpass.kumi.systems') ||
+    url.hostname === 'raw.githubusercontent.com'
   ) {
     // Tile images are not CORS-enabled — let them pass through as-is
     // without re-fetching through the SW (which would enforce CORS)

--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function loadSW() {
+  let fetchHandler = null;
+  const mockCache = { addAll: () => Promise.resolve(), put: () => Promise.resolve() };
+  const mockCaches = {
+    open:   () => Promise.resolve(mockCache),
+    match:  () => Promise.resolve(null),
+    keys:   () => Promise.resolve([]),
+    delete: () => Promise.resolve(),
+  };
+  const mockSelf = {
+    addEventListener: (type, handler) => {
+      if (type === 'fetch') fetchHandler = handler;
+    },
+    skipWaiting: () => {},
+    clients: { claim: () => {} },
+  };
+
+  const src = readFileSync(resolve(ROOT, 'sw.js'), 'utf8');
+  const ctx = vm.createContext({
+    self: mockSelf,
+    caches: mockCaches,
+    fetch: () => Promise.resolve(new Response('')),
+    URL, Response,
+  });
+  vm.runInContext(src, ctx);
+  return { fetchHandler, mockCaches };
+}
+
+function makeFetchEvent(url, { method = 'GET', destination = '' } = {}) {
+  let responded = false;
+  return {
+    request: { url, method, destination },
+    respondWith: () => { responded = true; },
+    get _responded() { return responded; },
+  };
+}
+
+describe('service worker fetch routing', () => {
+  let fetchHandler;
+  beforeEach(() => {
+    ({ fetchHandler } = loadSW());
+  });
+
+  it('does NOT intercept obs-history.json.gz (raw.githubusercontent.com)', () => {
+    const evt = makeFetchEvent(
+      'https://raw.githubusercontent.com/ncvangilse/vejr/data/obs-history.json.gz',
+    );
+    fetchHandler(evt);
+    expect(evt._responded).toBe(false);
+  });
+
+  it('does NOT intercept forecast-history.json.gz (raw.githubusercontent.com)', () => {
+    const evt = makeFetchEvent(
+      'https://raw.githubusercontent.com/ncvangilse/vejr/data/forecast-history.json.gz',
+    );
+    fetchHandler(evt);
+    expect(evt._responded).toBe(false);
+  });
+
+  it('does NOT intercept open-meteo API calls', () => {
+    const evt = makeFetchEvent('https://api.open-meteo.com/v1/forecast?lat=55&lon=12');
+    fetchHandler(evt);
+    expect(evt._responded).toBe(false);
+  });
+
+  it('intercepts vejr.html with respondWith (network-first)', () => {
+    const evt = makeFetchEvent('https://example.github.io/vejr.html', { destination: 'document' });
+    fetchHandler(evt);
+    expect(evt._responded).toBe(true);
+  });
+
+  it('intercepts icon PNG with respondWith (cache-first)', () => {
+    const evt = makeFetchEvent('https://example.github.io/icon-assets/icon-120.png');
+    fetchHandler(evt);
+    expect(evt._responded).toBe(true);
+  });
+
+  it('does NOT intercept non-GET requests', () => {
+    const evt = makeFetchEvent(
+      'https://raw.githubusercontent.com/ncvangilse/vejr/data/obs-history.json.gz',
+      { method: 'POST' },
+    );
+    fetchHandler(evt);
+    expect(evt._responded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the service worker's fetch routing logic and updates the caching strategy to exclude `raw.githubusercontent.com` from interception, ensuring dynamic data files are always fetched fresh from the network.

## Key Changes
- **Added service worker test suite** (`tests/sw.test.js`): Comprehensive tests for fetch event routing that verify:
  - External APIs (open-meteo, raw.githubusercontent.com) are not intercepted
  - Application assets (HTML documents, icons) are properly cached
  - Non-GET requests bypass the service worker
  
- **Updated fetch event handler** (`sw.js`): Added `raw.githubusercontent.com` to the network-only exclusion list to prevent caching of dynamically updated data files (specifically `obs-history.json.gz` which the Raspberry Pi updates every 10 minutes)

## Implementation Details
- The test suite uses Node.js `vm` module to execute the service worker code in an isolated context with mocked Web APIs (`caches`, `fetch`, `self`)
- Tests verify routing behavior by checking whether `respondWith()` is called on fetch events
- The service worker change ensures that frequently-updated historical observation data is always fetched fresh, preventing stale data from being served from cache

https://claude.ai/code/session_01DHM44jGQaN6Z6LRR62pLfD