### PR TITLE
Reduce map overlay line weights and improve bias label clarity

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -853,7 +853,7 @@ function _bearingBin(d) {
       const poly = L.polygon(latlngs, {
         color:  '#00c890',
         fill:   false,
-        weight: 2,
+        weight: 1,
         opacity: 0.75,
       }).addTo(radarMap);
       kiteSpotOutlineLayers.push(poly);
@@ -897,7 +897,7 @@ function _bearingBin(d) {
     // Dashed line from spot center toward wind source direction
     L.polyline([[lat, lon], [lat + dlat, lon + dlon]], {
       color:     isOptimal ? '#00c890' : '#888888',
-      weight:    2,
+      weight:    1,
       opacity:   0.9,
       dashArray: '5,4',
     }).addTo(group);
@@ -909,7 +909,7 @@ function _bearingBin(d) {
         color:       '#00c890',
         fillColor:   '#00c890',
         fillOpacity: 0.35,
-        weight:      2,
+        weight:      1,
         opacity:     0.8,
       }).addTo(group);
     }
@@ -1230,15 +1230,16 @@ function _bearingBin(d) {
               biasEl.dataset.loaded = '1';
               const b = _stationBias(key, sObj.fcst?.wind, sObj.fcst?.dir);
               if (b) {
-                const sign    = b.bias >= 0 ? '+' : '';
                 const absB    = Math.abs(b.bias);
                 const biasCol = absB > 2 ? '#e06020' : absB > 1 ? '#e0a020' : '#8899aa';
-                const label   = !b.stratified  ? 'Model bias'
-                              : b.interpolated ? 'Model bias (approx)'
-                              :                  'Model bias (current)';
+                const dir     = b.bias >= 0 ? 'overpredicts' : 'underpredicts';
+                const qual    = !b.stratified  ? ''
+                              : b.interpolated ? ' (approx)'
+                              :                  ' (current)';
+                const label   = `Model ${dir}${qual}`;
                 biasEl.innerHTML =
                   `<span style="color:#aaa;font-size:10px">${label}&nbsp;</span>` +
-                  `<span style="color:${biasCol};font-size:10px;font-weight:600">${sign}${b.bias.toFixed(1)}&nbsp;m/s</span>` +
+                  `<span style="color:${biasCol};font-size:10px;font-weight:600">${absB.toFixed(1)}&nbsp;m/s</span>` +
                   `<span style="color:#aaa;font-size:10px">&nbsp;·&nbsp;${b.n}h</span>`;
               } else {
                 biasEl.style.display = 'none';

--- a/radar.js
+++ b/radar.js
@@ -111,6 +111,58 @@ function _bearingBin(d) {
   return Math.floor(d / 45) * 45 % 360;
 }
 
+/**
+ * Read pre-computed forecast bias for a station from window.OBS_HISTORY.
+ * fcstWind / fcstDir are the current Open-Meteo forecast at that station —
+ * used to select the relevant (speed_bin × bearing_bin) bias cell.
+ *
+ * Lookup order:
+ *   1. Exact (speed_bin, bearing_bin) cell
+ *   2. IDW interpolation across all populated cells in the same station
+ *   3. Scalar mean fallback (no forecast conditions available or no strat data)
+ *
+ * Returns { bias, n, stratified, interpolated } or null.
+ */
+function _stationBias(key, fcstWind, fcstDir) {
+  const b = window.OBS_HISTORY?.[key]?.bias;
+  if (!b || b.n == null || b.wind == null) return null;
+
+  if (b.strat && fcstWind != null && fcstDir != null) {
+    const tSpd = _speedBin(fcstWind);
+    const tBrg = _bearingBin(fcstDir);
+
+    // 1. Exact match
+    const exact = b.strat[`${tSpd}_${tBrg}`];
+    if (exact) return { bias: exact.mean, n: exact.n, stratified: true, interpolated: false };
+
+    // 2. IDW interpolation across all populated cells
+    const SPEED_BINS   = [0, 4, 8, 12];
+    const BEARING_BINS = [0, 45, 90, 135, 180, 225, 270, 315];
+    const tSpdIdx = SPEED_BINS.indexOf(tSpd);
+    const tBrgIdx = BEARING_BINS.indexOf(tBrg);
+
+    let wSum = 0, bSum = 0, nMin = Infinity;
+    for (const [ck, cv] of Object.entries(b.strat)) {
+      const [cs, cb] = ck.split('_').map(Number);
+      const sSteps = Math.abs(SPEED_BINS.indexOf(cs) - tSpdIdx);
+      let bSteps = Math.abs(BEARING_BINS.indexOf(cb) - tBrgIdx);
+      if (bSteps > 4) bSteps = 8 - bSteps;  // circular wrap
+      const dist = Math.sqrt(sSteps * sSteps + bSteps * bSteps);
+      const w = 1 / (dist || 1e-9);
+      wSum += w;
+      bSum += w * cv.mean;
+      nMin = Math.min(nMin, cv.n);
+    }
+    if (wSum > 0) {
+      return { bias: bSum / wSum, n: nMin, stratified: true, interpolated: true };
+    }
+  }
+
+  // 3. Scalar fallback
+  return { bias: b.wind, n: b.n, stratified: false, interpolated: false };
+}
+window._stationBias = _stationBias;
+
 (function () {
   // Leaflet is loaded from CDN; bail out gracefully if it failed (offline / blocked).
   if (typeof L === 'undefined') {
@@ -986,57 +1038,6 @@ function _bearingBin(d) {
     } catch (_) {
       return null;
     }
-  }
-
-  /**
-   * Read pre-computed forecast bias for a station from window.OBS_HISTORY.
-   * fcstWind / fcstDir are the current Open-Meteo forecast at that station —
-   * used to select the relevant (speed_bin × bearing_bin) bias cell.
-   *
-   * Lookup order:
-   *   1. Exact (speed_bin, bearing_bin) cell
-   *   2. IDW interpolation across all populated cells in the same station
-   *   3. Scalar mean fallback (no forecast conditions available or no strat data)
-   *
-   * Returns { bias, n, stratified, interpolated } or null.
-   */
-  function _stationBias(key, fcstWind, fcstDir) {
-    const b = window.OBS_HISTORY?.[key]?.bias;
-    if (!b || b.n == null || b.wind == null) return null;
-
-    if (b.strat && fcstWind != null && fcstDir != null) {
-      const tSpd = _speedBin(fcstWind);
-      const tBrg = _bearingBin(fcstDir);
-
-      // 1. Exact match
-      const exact = b.strat[`${tSpd}_${tBrg}`];
-      if (exact) return { bias: exact.mean, n: exact.n, stratified: true, interpolated: false };
-
-      // 2. IDW interpolation across all populated cells
-      const SPEED_BINS   = [0, 4, 8, 12];
-      const BEARING_BINS = [0, 45, 90, 135, 180, 225, 270, 315];
-      const tSpdIdx = SPEED_BINS.indexOf(tSpd);
-      const tBrgIdx = BEARING_BINS.indexOf(tBrg);
-
-      let wSum = 0, bSum = 0, nMin = Infinity;
-      for (const [ck, cv] of Object.entries(b.strat)) {
-        const [cs, cb] = ck.split('_').map(Number);
-        const sSteps = Math.abs(SPEED_BINS.indexOf(cs) - tSpdIdx);
-        let bSteps = Math.abs(BEARING_BINS.indexOf(cb) - tBrgIdx);
-        if (bSteps > 4) bSteps = 8 - bSteps;  // circular wrap
-        const dist = Math.sqrt(sSteps * sSteps + bSteps * bSteps);
-        const w = 1 / (dist || 1e-9);
-        wSum += w;
-        bSum += w * cv.mean;
-        nMin = Math.min(nMin, cv.n);
-      }
-      if (wSum > 0) {
-        return { bias: bSum / wSum, n: nMin, stratified: true, interpolated: true };
-      }
-    }
-
-    // 3. Scalar fallback
-    return { bias: b.wind, n: b.n, stratified: false, interpolated: false };
   }
 
   const DIR_DEG = {

--- a/tests/radar.test.js
+++ b/tests/radar.test.js
@@ -5,7 +5,7 @@ import { loadScripts } from './helpers/loader.js';
 // early, but module-level helpers defined before the IIFE are still available.
 const ctx = loadScripts('radar.js');
 const { _parseNominatimPlace, _nominatimHasLocalDetail, _clampMenuPos, _buildProposeNameUrl,
-        _speedBin, _bearingBin } = ctx;
+        _speedBin, _bearingBin, _stationBias } = ctx;
 
 describe('OBS_HISTORY_URL', () => {
   it('points to raw.githubusercontent.com data branch', () => {
@@ -275,4 +275,69 @@ describe('_bearingBin', () => {
   it('270° → 270', () => expect(_bearingBin(270)).toBe(270));
   it('315° → 315', () => expect(_bearingBin(315)).toBe(315));
   it('359° → 315', () => expect(_bearingBin(359)).toBe(315));
+});
+
+describe('_stationBias', () => {
+  beforeEach(() => { ctx.window.OBS_HISTORY = {}; });
+  afterEach(()  => { ctx.window.OBS_HISTORY = undefined; });
+
+  it('returns null when station has no bias field', () => {
+    ctx.window.OBS_HISTORY = { 'ninjo:1': { obs: [] } };
+    expect(_stationBias('ninjo:1')).toBeNull();
+  });
+
+  it('returns null when OBS_HISTORY has no entry for the key', () => {
+    expect(_stationBias('ninjo:missing')).toBeNull();
+  });
+
+  it('returns scalar bias when no strat data and no fcst', () => {
+    ctx.window.OBS_HISTORY = { 'ninjo:1': { bias: { wind: 1.5, n: 30 } } };
+    const r = _stationBias('ninjo:1');
+    expect(r).toEqual({ bias: 1.5, n: 30, stratified: false, interpolated: false });
+  });
+
+  it('returns negative scalar bias (underpredicts)', () => {
+    ctx.window.OBS_HISTORY = { 'ninjo:1': { bias: { wind: -0.8, n: 12 } } };
+    const r = _stationBias('ninjo:1');
+    expect(r.bias).toBeCloseTo(-0.8);
+    expect(r.stratified).toBe(false);
+  });
+
+  it('uses scalar fallback when no fcst provided even if strat is present', () => {
+    ctx.window.OBS_HISTORY = {
+      'ninjo:1': { bias: { wind: 1.0, n: 10, strat: { '4_270': { mean: 2.0, n: 8 } } } },
+    };
+    const r = _stationBias('ninjo:1', null, null);
+    expect(r).toEqual({ bias: 1.0, n: 10, stratified: false, interpolated: false });
+  });
+
+  it('returns exact stratified cell when available', () => {
+    ctx.window.OBS_HISTORY = {
+      'ninjo:1': { bias: { wind: 1.0, n: 10, strat: { '4_270': { mean: 2.5, n: 8 } } } },
+    };
+    const r = _stationBias('ninjo:1', 5, 270);  // speed 5 → bin 4, dir 270 → bin 270
+    expect(r).toEqual({ bias: 2.5, n: 8, stratified: true, interpolated: false });
+  });
+
+  it('returns IDW-interpolated result when no exact cell matches', () => {
+    ctx.window.OBS_HISTORY = {
+      'ninjo:1': { bias: { wind: 1.0, n: 10, strat: {
+        '4_270': { mean: 2.0, n: 8 },
+        '8_270': { mean: 4.0, n: 7 },
+      }}},
+    };
+    // fcst speed 6 → bin 4, dir 350 → bin 315 — neither cell matches exactly
+    const r = _stationBias('ninjo:1', 6, 350);
+    expect(r.stratified).toBe(true);
+    expect(r.interpolated).toBe(true);
+    expect(r.bias).toBeGreaterThan(2.0);
+  });
+
+  it('falls back to scalar when strat is present but IDW produces no weight (empty strat)', () => {
+    ctx.window.OBS_HISTORY = {
+      'ninjo:1': { bias: { wind: 1.0, n: 10, strat: {} } },
+    };
+    const r = _stationBias('ninjo:1', 5, 270);
+    expect(r).toEqual({ bias: 1.0, n: 10, stratified: false, interpolated: false });
+  });
 });


### PR DESCRIPTION
## Summary
This PR makes two main improvements to the radar visualization:
1. Reduces the visual weight of map overlay lines for a cleaner appearance
2. Refactors the model bias display to use more intuitive language

## Key Changes
- **Line weight reduction**: Decreased the `weight` property from 2 to 1 for:
  - Kite spot outline polygons
  - Wind direction indicator lines
  - Wind direction circles
  
  This creates a less cluttered map visualization while maintaining visibility.

- **Bias label refactoring**: Improved the model bias display text:
  - Changed from showing signed values (e.g., "+1.5 m/s") to showing absolute values with directional language
  - Replaced "Model bias" label with more descriptive "Model overpredicts" or "Model underpredicts"
  - Simplified qualification suffixes: "(approx)" and "(current)" instead of full "Model bias (approx)" phrases
  - Removed the explicit `sign` variable and now uses `absB` (absolute bias) for display
  - Final format: "Model [overpredicts|underpredicts][qualification]" followed by the absolute bias value

## Implementation Details
The bias label construction now uses template literals to compose the label dynamically based on whether the bias is positive/negative and whether the data is stratified/interpolated, resulting in clearer, more concise user-facing text.

https://claude.ai/code/session_01GwixaKoPKXguMEgGXLpHw2