### PR TITLE
fix(tooltip): temperature hover dot tracks curve when temps1h has nulls

### DIFF
--- a/charts.js
+++ b/charts.js
@@ -192,8 +192,9 @@ function drawTemp(times, temps, precips, ensTemp, ensPrecip, times3h, precips3h,
     ctx.fillRect(0, 0, cssW, cssH);
   }
   const padT=8, padB=8, ch=cssH-padT-padB;
-  let tmin=Math.floor(Math.min(...temps)/5)*5;
-  let tmax=Math.ceil( Math.max(...temps)/5)*5;
+  const validTs = temps.filter(v => v != null);
+  let tmin=Math.floor(Math.min(...validTs)/5)*5;
+  let tmax=Math.ceil( Math.max(...validTs)/5)*5;
   if (tmax-tmin < 15) { const mid=(tmin+tmax)/2; tmin=Math.floor((mid-7.5)/5)*5; tmax=tmin+15; }
   const tRange=tmax-tmin;
   const ty=t=>padT+(1-(t-tmin)/tRange)*ch;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1241,6 +1241,73 @@ describe('drawCrosshairs consistent x across rows', () => {
   });
 });
 
+// ── temperature dot y tracks the curve (null-coercion guard) ─────────────────
+
+describe('drawCrosshairs temperature dot y-position', () => {
+  it('places the dot on the curve even when temps1h contains null values', () => {
+    // When temps1h has nulls, Math.min/max without filtering coerces null→0 and
+    // produces a different tmin/tmax than tooltip.js (which filters nulls).
+    // This caused the dot to appear above/below the actual temperature curve.
+    // Both drawTemp (charts.js) and drawCrosshairs (tooltip.js) must use the
+    // null-filtered scale so the dot sits exactly on the drawn line.
+
+    const { ctx } = loadApp();
+    ctx._windAxisMax = () => 20;
+
+    // temps1h has nulls at positions 0 and 5; non-null temps are all 12–15°C.
+    // Null-filtered: tmin=10 → expanded to tmin=5, tmax=20, tRange=15.
+    // Un-filtered:   tmin=0  (null→0), tmax=15, tRange=15 → completely wrong scale.
+    ctx.lastRenderedData = {
+      times:     ['2025-01-01T00:00', '2025-01-01T03:00'],
+      times1h:   Array.from({ length: 6 }, (_, i) => `2025-01-01T0${i}:00`),
+      temps1h:   [null, 12, 13, 14, 15, null],
+      winds1h:   Array(6).fill(5),
+      ensWind1h: null,
+      ensGust1h: null,
+      xMap1h:    [15, 25, 35, 45, 55, 65],
+      slotIdx1h: [0, 0, 0, 1, 1, 1],
+    };
+
+    // Capture arc(x, y, ...) on xh-temp to read the dot's y-position.
+    let tempDotY = null;
+    const origGetEl = ctx.document.getElementById;
+    ctx.document.getElementById = (id) => {
+      if (['xh-top', 'xh-temp', 'xh-dir', 'xh-wind'].includes(id)) {
+        const isTemp = id === 'xh-temp';
+        return {
+          width: 60, height: 130, style: {},
+          getContext: () => ({
+            clearRect() {}, save() {}, restore() {}, scale() {},
+            beginPath() {}, stroke() {}, fill() {}, moveTo() {}, lineTo() {},
+            setLineDash() {}, fillText() {},
+            arc(x, y) { if (isTemp) tempDotY = y; },
+            font: '', fillStyle: '', strokeStyle: '',
+            lineWidth: 0, textBaseline: '', textAlign: '',
+            measureText: () => ({ width: 0 }),
+          }),
+        };
+      }
+      if (['c-top', 'c-temp', 'c-dir', 'c-wind'].includes(id))
+        return { width: 60, height: 130 };
+      return origGetEl(id);
+    };
+
+    // idx1h=2 → tempVal = 13°C
+    ctx.drawCrosshairs(0.5, 2, 0);
+
+    // Expected scale (null-filtered): tmin=5, tmax=20, tRange=15
+    // dotY = TEMP_padT + (1 - (13-5)/15) * TEMP_ch = 8 + (7/15)*114 ≈ 61.2
+    const TEMP_padT = 8, TEMP_ch = 114;
+    const expectedY = TEMP_padT + (1 - (13 - 5) / 15) * TEMP_ch;
+    expect(tempDotY).toBeCloseTo(expectedY, 1);
+
+    // Verify it is NOT at the wrong position produced by un-filtered scale
+    // (tmin=0, dotY = 8 + (1 - 13/15)*114 ≈ 23.2) — a 38px error.
+    const wrongY = TEMP_padT + (1 - 13 / 15) * TEMP_ch;
+    expect(Math.abs(tempDotY - wrongY)).toBeGreaterThan(5);
+  });
+});
+
 // ── showCurrentTimeCrosshair (Issue 120) ──────────────────────────────────────
 
 function makeXhSetup(ctx) {

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -542,3 +542,76 @@ describe('drawWind TRAFIK_OBS axis contribution', () => {
     expect(() => getMaxW(dmiObs, null)).not.toThrow();
   });
 });
+
+// ── drawTemp: temperature scale ignores null values ───────────────────────────
+
+describe('drawTemp temperature scale with null values', () => {
+  // When temps contains null values, Math.min/max without filtering treats
+  // null as 0 (JS coercion), producing a wrong tmin/tmax.  drawTemp must
+  // filter nulls first so its scale matches drawCrosshairs (tooltip.js).
+
+  const T0 = new Date('2024-06-15T10:00:00Z').getTime();
+  const times = Array.from({ length: 6 }, (_, i) => new Date(T0 + i * 3600000).toISOString());
+
+  function makeDomEl() {
+    return { style: {}, innerHTML: '', textContent: '', title: '', appendChild: () => {} };
+  }
+
+  function runDrawTemp(temps) {
+    const { ctx2d, canvas } = makeTrackingCanvas();
+    canvas.parentElement = { clientWidth: 400 };
+    const vmCtx = loadChartLogic();
+    vmCtx.document = {
+      getElementById: (id) => id === 'c-temp' ? canvas : makeDomEl(),
+      createElement: () => makeDomEl(),
+    };
+    const precips = Array(6).fill(0);
+    // Call with xMap=null so cx2 uses uniform spacing — easy to ignore for y checks.
+    vmCtx.drawTemp(times, temps, precips, null, null, null, null, null, false, 400, null);
+    return ctx2d.calls;
+  }
+
+  it('draws the temperature line at y positions based on null-filtered scale', () => {
+    // temps: null at 0 and 5; non-null range is 12–15°C.
+    // Null-filtered: tmin=10→5 (expanded), tmax=15→20, tRange=15.
+    // Un-filtered:   tmin=0  (null→0),     tmax=15,    tRange=15 → wrong.
+    const temps = [null, 12, 13, 14, 15, null];
+    const calls = runDrawTemp(temps);
+
+    // Find the first moveTo that starts a temperature line segment.
+    // The line is drawn for indices 1→2, 2→3, 3→4 (skipping null ends).
+    // With correct scale, py(12) = 8 + (1 - (12-5)/15)*114 ≈ 68.8.
+    // With wrong scale,  py(12) = 8 + (1 - 12/15)*114      ≈ 30.8.
+    const lineMoves = calls.filter(c => c.op === 'moveTo');
+    // Pick the moveTo y-values that are above the mid-chart (> 50) — these
+    // correspond to temperatures in the valid 12–15°C range under the correct scale.
+    const TEMP_padT = 8, TEMP_ch = 114;
+    const expectedY12 = TEMP_padT + (1 - (12 - 5) / 15) * TEMP_ch; // ≈ 68.8
+    const wrongY12    = TEMP_padT + (1 -  12       / 15) * TEMP_ch; // ≈ 30.8
+
+    // At least one moveTo should match the correct y for 12°C.
+    const correctHit = lineMoves.some(c => Math.abs(c.y - expectedY12) < 1);
+    const wrongHit   = lineMoves.some(c => Math.abs(c.y - wrongY12)    < 1);
+
+    expect(correctHit).toBe(true);   // curve drawn at correct (null-filtered) scale
+    expect(wrongHit).toBe(false);    // NOT at the wrong (null-coerced-to-0) scale
+  });
+
+  it('produces the same y scale whether or not leading/trailing nulls are present', () => {
+    // A clean array and one with nulls should produce the same curve y positions.
+    const tempsClean = [12, 12, 13, 14, 15, 15];
+    const tempsNulls = [null, 12, 13, 14, 15, null];
+
+    const callsClean = runDrawTemp(tempsClean);
+    const callsNulls = runDrawTemp(tempsNulls);
+
+    const yClean = callsClean.filter(c => c.op === 'moveTo').map(c => c.y);
+    const yNulls = callsNulls.filter(c => c.op === 'moveTo').map(c => c.y);
+
+    // Both should contain y ≈ 68.8 for 12°C (correct scale).
+    const TEMP_padT = 8, TEMP_ch = 114;
+    const expected12 = TEMP_padT + (1 - (12 - 5) / 15) * TEMP_ch;
+    expect(yClean.some(y => Math.abs(y - expected12) < 1)).toBe(true);
+    expect(yNulls.some(y => Math.abs(y - expected12) < 1)).toBe(true);
+  });
+});


### PR DESCRIPTION
drawTemp computed tmin/tmax with Math.min/max spread over the raw temps
array, where null values coerce to 0. This gave a different scale than
drawCrosshairs (tooltip.js), which already filtered nulls before the same
calculation. When any entry in temps1h is null (e.g. partial API response),
the y-axis scale differed — placing the dot up to ~38 px from the curve.

Fix: filter nulls in drawTemp before computing tmin/tmax, matching the
null-safe path already used in tooltip.js.

Tests added in charts.test.js (drawTemp draws at correct y with nulls)
and app.test.js (drawCrosshairs dot y uses null-filtered scale).

https://claude.ai/code/session_0174PpStRFJFvmAi9vtNHb2S