### PR TITLE
Make kite config modal scrollable, lock body scroll when open

### DIFF
--- a/app.js
+++ b/app.js
@@ -651,9 +651,18 @@ async function loadNearestObsStation(lat, lon, opts = {}) {
     updateShoreStatusUI();
   };
 
+  function openKiteModal() {
+    overlay.classList.add('open');
+    document.body.classList.add('modal-open');
+  }
+  function closeKiteModal() {
+    overlay.classList.remove('open');
+    document.body.classList.remove('modal-open');
+  }
+
   cfgBtn.addEventListener('click', () => {
     syncDialogToConfig(KITE_CFG);
-    overlay.classList.add('open');
+    openKiteModal();
     // Ensure raster + vector data is fetched (or retried if a previous attempt failed).
     // Both functions deduplicate in-flight requests, so duplicate calls are free.
     if (lastShoreCoords) {
@@ -662,14 +671,14 @@ async function loadNearestObsStation(lat, lon, opts = {}) {
     }
     requestAnimationFrame(() => { drawModalCompass(); updateShoreStatusUI(); renderShoreDebug(); });
   });
-  cancelBtn.addEventListener('click', () => overlay.classList.remove('open'));
-  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.classList.remove('open'); });
+  cancelBtn.addEventListener('click', closeKiteModal);
+  overlay.addEventListener('click', e => { if (e.target === overlay) closeKiteModal(); });
   resetBtn.addEventListener('click', () => { syncDialogToConfig(KITE_DEFAULTS); drawModalCompass(); });
   applyBtn.addEventListener('click', () => {
     const cfg = readDialogConfig();
     window.setShoreSeaThresh(cfg.seaThresh);   // commit threshold before re-render
     setKiteParams(cfg);
-    overlay.classList.remove('open');
+    closeKiteModal();
     if (lastData) renderDisplay(lastData);
   });
 

--- a/vejr.css
+++ b/vejr.css
@@ -22,6 +22,7 @@ body {
            max(8px, env(safe-area-inset-bottom))
            max(8px, env(safe-area-inset-left));
 }
+body.modal-open { overflow: hidden; }
 #header-left {
   display: flex;
   flex-direction: column;
@@ -686,6 +687,8 @@ canvas.main-canvas {
   min-width: 280px;
   max-width: 360px;
   width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
   color: #e8f5ef;
   font-family: 'IBM Plex Sans', sans-serif;
   box-shadow: 0 8px 32px rgba(0,0,0,0.55);

--- a/vejr.html
+++ b/vejr.html
@@ -35,7 +35,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@400;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="vejr.css?v=33">
+<link rel="stylesheet" href="vejr.css?v=34">
 </head>
 <body>
 <div id="rotator">


### PR DESCRIPTION
- Add max-height: 90vh + overflow-y: auto to #kite-modal so the modal
  scrolls its own content on small screens instead of the page behind it
- Add body.modal-open { overflow: hidden } CSS rule
- Toggle modal-open class on body open/close via openKiteModal/closeKiteModal helpers
- Bump CSS version to v=34

https://claude.ai/code/session_014wtjNmriq4fdDmdZCicKF2