### PR TITLE
Implement progressive ensemble loading for faster initial render

### DIFF
--- a/app.js
+++ b/app.js
@@ -1247,6 +1247,13 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
     window.addEventListener('touchend',   onSpotPointerUp);
   }
 
+  // Redraw spot compass when Overpass vector coastline data arrives.
+  // The raster analysis and vector fetch run in parallel; without this listener
+  // the coastline overlay would never appear if the vector fetch finishes last.
+  window.addEventListener('shore-vector-ready', () => {
+    if (overlay.classList.contains('open')) requestAnimationFrame(() => drawSpotCompass());
+  });
+
   cancelBtn.addEventListener('click', () => overlay.classList.remove('open'));
   overlay.addEventListener('click', e => { if (e.target === overlay) overlay.classList.remove('open'); });
 

--- a/app.js
+++ b/app.js
@@ -1068,8 +1068,8 @@ if (window.setObsToggleCallback) {
 
 // ── Kite spot callbacks ───────────────────────────────────────────────────
 if (window.setCreateKiteSpotCallback) {
-  window.setCreateKiteSpotCallback((lat, lon) => {
-    if (window.openKiteSpotDialog) window.openKiteSpotDialog(lat, lon);
+  window.setCreateKiteSpotCallback((lat, lon, name) => {
+    if (window.openKiteSpotDialog) window.openKiteSpotDialog(lat, lon, name);
   });
 }
 if (window.setKiteSpotClickCallback) {
@@ -1164,7 +1164,6 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
   let pendingLat   = null;
   let pendingLon   = null;
   let spotBearings = [];    // currently selected bearings
-  let spotMask     = null;  // Float32Array[36] from analyseShore for this spot
   let spotDragMode = null;  // 'add' | 'remove'
   let spotLastSlot = null;
 
@@ -1185,7 +1184,7 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
     ctx.scale(dpr, dpr);
     ctx.clearRect(0, 0, SIZE, SIZE);
     window.drawShoreCompass(ctx, SIZE / 2, SIZE / 2, SIZE / 2 - 2,
-      spotMask, null, false, spotBearings, KITE_CFG.seaThresh);
+      window.SHORE_MASK, null, false, spotBearings, KITE_CFG.seaThresh);
   }
 
   function bearingFromPointer(canvas, clientX, clientY) {
@@ -1248,10 +1247,21 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
   }
 
   // Redraw spot compass when Overpass vector coastline data arrives.
-  // The raster analysis and vector fetch run in parallel; without this listener
-  // the coastline overlay would never appear if the vector fetch finishes last.
   window.addEventListener('shore-vector-ready', () => {
     if (overlay.classList.contains('open')) requestAnimationFrame(() => drawSpotCompass());
+  });
+
+  // Auto-populate bearings and redraw when raster analysis completes.
+  window.addEventListener('shore-mask-ready', () => {
+    if (!overlay.classList.contains('open')) return;
+    if (window.SHORE_MASK && spotBearings.length === 0) {
+      const thresh = KITE_CFG.seaThresh;
+      for (let b = 0; b < SHORE_BEARINGS; b++) {
+        if (window.SHORE_MASK[b] >= thresh) spotBearings.push(b * 10);
+      }
+    }
+    setStatus('');
+    requestAnimationFrame(() => drawSpotCompass());
   });
 
   cancelBtn.addEventListener('click', () => overlay.classList.remove('open'));
@@ -1276,36 +1286,55 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
     }
   });
 
-  window.openKiteSpotDialog = function (lat, lon) {
+  window.openKiteSpotDialog = function (lat, lon, suggestedName) {
     pendingLat   = lat;
     pendingLon   = lon;
     spotBearings = [];
-    spotMask     = null;
-    if (nameInput) nameInput.value = '';
     overlay.classList.add('open');
-    setStatus('🌊 Detecting sea bearings…');
-    requestAnimationFrame(() => drawSpotCompass());
 
+    if (nameInput) {
+      if (suggestedName) {
+        nameInput.value = suggestedName;
+      } else {
+        nameInput.value = '';
+        // Async fallback: geocode the spot location for a readable name.
+        fetch(
+          `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json&addressdetails=1`,
+          { headers: { 'Accept-Language': 'en' } }
+        ).then(r => r.ok ? r.json() : null).then(d => {
+          if (!d || !nameInput) return;
+          const a = d.address || {};
+          const name = a.beach || a.leisure || a.natural
+                    || a.neighbourhood || a.suburb || a.hamlet || a.village
+                    || a.town || a.city_district || a.city
+                    || (d.display_name ? d.display_name.split(',')[0] : null);
+          if (name && nameInput.value === '') nameInput.value = name;
+        }).catch(() => null);
+      }
+    }
+
+    // Trigger/chain analysis (deduplicates if already in-flight from context-menu prefetch).
+    // If fast-path hits (cached coords), SHORE_MASK is already populated after this call.
     if (window.analyseShore) {
-      window.analyseShore(lat, lon, () => {
-        spotMask = window.SHORE_MASK;
-        if (spotMask) {
-          const thresh = KITE_CFG.seaThresh;
-          spotBearings = [];
-          for (let b = 0; b < SHORE_BEARINGS; b++) {
-            if (spotMask[b] >= thresh) spotBearings.push(b * 10);
-          }
-          setStatus('');
-        } else {
+      Promise.resolve(window.analyseShore(lat, lon)).then(() => {
+        if (overlay.classList.contains('open') && !window.SHORE_MASK && spotBearings.length === 0) {
           setStatus('⚠ Could not detect sea bearings — select manually');
         }
-        drawSpotCompass();
-      }).catch(() => {
-        setStatus('⚠ Could not detect sea bearings — select manually');
-      });
-    } else {
-      setStatus('');
+      }).catch(() => null);
     }
+
+    // Immediately use cached mask if available (fast-path or completed prefetch).
+    if (window.SHORE_MASK) {
+      const thresh = KITE_CFG.seaThresh;
+      for (let b = 0; b < SHORE_BEARINGS; b++) {
+        if (window.SHORE_MASK[b] >= thresh) spotBearings.push(b * 10);
+      }
+      setStatus('');
+    } else {
+      setStatus('🌊 Detecting sea bearings…');
+    }
+
+    requestAnimationFrame(() => drawSpotCompass());
   };
 })();
 

--- a/app.js
+++ b/app.js
@@ -63,6 +63,74 @@ function syncInvertedColorsClass() {
   document.body.classList.toggle('inverted-colors', on);
 }
 /* ══════════════════════════════════════════════════
+   MODEL / ENSEMBLE LABELS  (shared by load, loadAtCoords, applyEnsembleData)
+══════════════════════════════════════════════════ */
+const MODEL_LABEL = {
+  'best_match':          'Auto',
+  'dmi_seamless':        'DMI HARMONIE',
+  'icon_seamless':       'DWD ICON',
+  'ecmwf_ifs025':        'ECMWF IFS',
+  'meteofrance_seamless':'Météo-France',
+  'gfs_seamless':        'NOAA GFS',
+};
+const ENS_LABEL = {
+  'best_match':          'ICON-EPS',
+  'dmi_seamless':        'ICON-EPS',
+  'icon_seamless':       'ICON-EPS',
+  'ecmwf_ifs025':        'IFS-EPS',
+  'meteofrance_seamless':'ICON-EPS',
+  'gfs_seamless':        'GFS-EPS',
+};
+
+// Applies ensemble percentile data onto an existing lastData object, rebuilding
+// the merged center-line arrays from the stored deterministic snapshots.
+// Called asynchronously once ensPromise resolves so weather renders first.
+function applyEnsembleData(d, ensData, model) {
+  const modelLabel = MODEL_LABEL[model] || model;
+  const ensLabel   = ENS_LABEL[model]   || 'ensemble';
+  const ensStatus  = document.getElementById('ens-status');
+  if (ensData && ensData.hourly) {
+    const ensTemp    = ensemblePercentiles(ensData.hourly, 'temperature_2m');
+    const ensWind    = ensemblePercentiles(ensData.hourly, 'windspeed_10m');
+    const ensGust    = ensemblePercentiles(ensData.hourly, 'windgusts_10m');
+    const ensPrecip  = ensemblePercentiles(ensData.hourly, 'precipitation');
+    const ensTemp1h  = ensemblePercentiles(ensData.hourly, 'temperature_2m',  STEP1H);
+    const ensWind1h  = ensemblePercentiles(ensData.hourly, 'windspeed_10m',   STEP1H);
+    const ensGust1h  = ensemblePercentiles(ensData.hourly, 'windgusts_10m',   STEP1H);
+    const ensPrecip1h = ensemblePercentiles(ensData.hourly, 'precipitation',  STEP1H);
+    // Rebuild merged arrays from stored deterministic originals
+    const temps    = d.detTemps.slice(),     winds    = d.detWinds.slice();
+    const precips  = d.detPrecips.slice(),   gusts    = d.detGusts.slice();
+    const temps1h  = d.detTemps1h.slice(),   winds1h  = d.detWinds1h.slice();
+    const precips1h = d.detPrecips1h.slice(), gusts1h = d.detGusts1h.slice();
+    if (ensTemp)    for (let i = 0; i < temps.length;    i++) { if (ensTemp.p50[i]    != null) temps[i]    = ensTemp.p50[i];    }
+    if (ensWind)    for (let i = 0; i < winds.length;    i++) { if (ensWind.p50[i]    != null) winds[i]    = ensWind.p50[i];    }
+    if (ensPrecip)  for (let i = 0; i < precips.length;  i++) { if (ensPrecip.p50[i]  != null) precips[i]  = ensPrecip.p50[i];  }
+    if (ensTemp1h)  for (let i = 0; i < temps1h.length;  i++) { if (ensTemp1h.p50[i]  != null) temps1h[i]  = ensTemp1h.p50[i];  }
+    if (ensWind1h)  for (let i = 0; i < winds1h.length;  i++) { if (ensWind1h.p50[i]  != null) winds1h[i]  = ensWind1h.p50[i];  }
+    if (ensPrecip1h) for (let i = 0; i < precips1h.length; i++) { if (ensPrecip1h.p50[i] != null) precips1h[i] = ensPrecip1h.p50[i]; }
+    // Gusts must stay >= ensemble-merged wind line
+    for (let i = 0; i < gusts.length;   i++) gusts[i]   = Math.max(gusts[i],   winds[i]);
+    for (let i = 0; i < gusts1h.length; i++) gusts1h[i] = Math.max(gusts1h[i], winds1h[i]);
+    d.temps = temps; d.winds = winds; d.precips = precips; d.gusts = gusts;
+    d.temps1h = temps1h; d.winds1h = winds1h; d.precips1h = precips1h; d.gusts1h = gusts1h;
+    d.ensTemp = ensTemp; d.ensWind = ensWind; d.ensGust = ensGust; d.ensPrecip = ensPrecip;
+    d.ensTemp1h = ensTemp1h; d.ensWind1h = ensWind1h; d.ensGust1h = ensGust1h; d.ensPrecip1h = ensPrecip1h;
+    const memberCount = Object.keys(ensData.hourly).filter(k => k.startsWith('temperature_2m_member')).length;
+    if (ensStatus) { ensStatus.textContent = `${modelLabel} + ${ensLabel} (${memberCount} mdl) ✓`; ensStatus.style.color = '#5a9'; }
+  } else {
+    d.ensTemp = null; d.ensWind = null; d.ensGust = null; d.ensPrecip = null;
+    d.ensTemp1h = null; d.ensWind1h = null; d.ensGust1h = null; d.ensPrecip1h = null;
+    // Reset center-line arrays to deterministic values
+    d.temps = d.detTemps.slice(); d.winds = d.detWinds.slice();
+    d.precips = d.detPrecips.slice(); d.gusts = d.detGusts.slice();
+    d.temps1h = d.detTemps1h.slice(); d.winds1h = d.detWinds1h.slice();
+    d.precips1h = d.detPrecips1h.slice(); d.gusts1h = d.detGusts1h.slice();
+    if (ensStatus) { ensStatus.textContent = `${modelLabel} — ensemble not available`; ensStatus.style.color = '#a77'; }
+  }
+}
+
+/* ══════════════════════════════════════════════════
    LOAD
 ══════════════════════════════════════════════════ */
 async function load(cityName, model) {
@@ -85,14 +153,16 @@ async function load(cityName, model) {
     lastShoreCoords = { lat: loc.latitude, lon: loc.longitude };
     if (window.fetchShoreVector) window.fetchShoreVector(loc.latitude, loc.longitude).catch(() => null);
     if (window.analyseShore)     window.analyseShore(loc.latitude, loc.longitude).catch(() => null);
-    // fetch main forecast + ensemble in parallel; ensemble failure is non-fatal.
+    // Start ensemble and obs lookup immediately — they run in parallel with weather.
+    // Only weather is on the critical path; ensemble bands are applied after first render.
+    const ensPromise = fetchEnsemble(loc.latitude, loc.longitude, model).catch(() => null);
+    loadNearestObsStation(loc.latitude, loc.longitude).catch(() => null);
     const iconCodeFetch = (model === 'dmi_seamless')
       ? fetch(`https://api.open-meteo.com/v1/forecast?latitude=${loc.latitude}&longitude=${loc.longitude}&hourly=weathercode&forecast_days=${FORECAST_DAYS}&timezone=auto&models=icon_seamless`)
           .then(r => r.ok ? r.json() : null).catch(() => null)
       : Promise.resolve(null);
-    const [data, ensData, iconData] = await Promise.all([
+    const [data, iconData] = await Promise.all([
       fetchWeather(loc.latitude, loc.longitude, model),
-      fetchEnsemble(loc.latitude, loc.longitude, model).catch(() => null),
       iconCodeFetch,
     ]);
     const H = data.hourly;
@@ -142,65 +212,15 @@ async function load(cityName, model) {
         ? iconCode1h : dmiCode1h);
       dirs1h.push(H.winddirection_10m[i]);
     }
-    const MODEL_LABEL = {
-      'best_match':          'Auto',
-      'dmi_seamless':        'DMI HARMONIE',
-      'icon_seamless':       'DWD ICON',
-      'ecmwf_ifs025':        'ECMWF IFS',
-      'meteofrance_seamless':'Météo-France',
-      'gfs_seamless':        'NOAA GFS',
-    };
-    const ENS_LABEL = {
-      'best_match':          'ICON-EPS',
-      'dmi_seamless':        'ICON-EPS',
-      'icon_seamless':       'ICON-EPS',
-      'ecmwf_ifs025':        'IFS-EPS',
-      'meteofrance_seamless':'ICON-EPS',
-      'gfs_seamless':        'GFS-EPS',
-    };
+    // Snapshot deterministic arrays before any ensemble merge; stored in lastData so
+    // applyEnsembleData can rebuild them correctly when ensPromise resolves.
+    const detTemps    = temps.slice(),    detWinds    = winds.slice();
+    const detPrecips  = precips.slice(),  detGusts    = gusts.slice();
+    const detTemps1h  = temps1h.slice(),  detWinds1h  = winds1h.slice();
+    const detPrecips1h = precips1h.slice(), detGusts1h = gusts1h.slice();
     const modelLabel = MODEL_LABEL[model] || model;
-    const ensLabel   = ENS_LABEL[model]   || 'ensemble';
-    let ensTemp = null, ensWind = null, ensGust = null, ensPrecip = null;
-    let ensTemp1h = null, ensWind1h = null, ensGust1h = null, ensPrecip1h = null;
     const ensStatus = document.getElementById('ens-status');
-    if (ensData && ensData.hourly) {
-      ensTemp   = ensemblePercentiles(ensData.hourly, 'temperature_2m');
-      ensWind   = ensemblePercentiles(ensData.hourly, 'windspeed_10m');
-      ensGust   = ensemblePercentiles(ensData.hourly, 'windgusts_10m');
-      ensPrecip = ensemblePercentiles(ensData.hourly, 'precipitation');
-      ensTemp1h   = ensemblePercentiles(ensData.hourly, 'temperature_2m',   STEP1H);
-      ensWind1h   = ensemblePercentiles(ensData.hourly, 'windspeed_10m',    STEP1H);
-      ensGust1h   = ensemblePercentiles(ensData.hourly, 'windgusts_10m',    STEP1H);
-      ensPrecip1h = ensemblePercentiles(ensData.hourly, 'precipitation',    STEP1H);
-      // Snapshot the deterministic gusts BEFORE merging ensemble wind into winds[].
-      // The ensemble p50 wind is often higher than the deterministic wind; if we let
-      // gusts get clamped against it the gust-wind gap collapses to zero.
-      const detGusts = gusts.slice();
-      const detGusts1h = gusts1h.slice();
-      // Replace deterministic slots with ensemble median (p50) where available.
-      if (ensTemp)
-        for (let i = 0; i < temps.length;   i++) { if (ensTemp.p50[i]   != null) temps[i]   = ensTemp.p50[i];   }
-      if (ensWind)
-        for (let i = 0; i < winds.length;   i++) { if (ensWind.p50[i]   != null) winds[i]   = ensWind.p50[i];   }
-      if (ensPrecip)
-        for (let i = 0; i < precips.length; i++) { if (ensPrecip.p50[i] != null) precips[i] = ensPrecip.p50[i]; }
-      if (ensTemp1h)
-        for (let i = 0; i < temps1h.length;   i++) { if (ensTemp1h.p50[i]   != null) temps1h[i]   = ensTemp1h.p50[i];   }
-      if (ensWind1h)
-        for (let i = 0; i < winds1h.length;   i++) { if (ensWind1h.p50[i]   != null) winds1h[i]   = ensWind1h.p50[i];   }
-      if (ensPrecip1h)
-        for (let i = 0; i < precips1h.length; i++) { if (ensPrecip1h.p50[i] != null) precips1h[i] = ensPrecip1h.p50[i]; }
-      // Restore deterministic gusts unchanged — they are already >= det wind from the
-      // initial data loop, and they must stay above the (now ensemble-merged) wind line.
-      for (let i = 0; i < gusts.length;   i++) gusts[i]   = Math.max(detGusts[i],   winds[i]);
-      for (let i = 0; i < gusts1h.length; i++) gusts1h[i] = Math.max(detGusts1h[i], winds1h[i]);
-      const memberCount = Object.keys(ensData.hourly).filter(k => k.startsWith('temperature_2m_member')).length;
-      ensStatus.textContent = `${modelLabel} + ${ensLabel} (${memberCount} mdl) ✓`;
-      ensStatus.style.color = '#5a9';
-    } else {
-      ensStatus.textContent = `${modelLabel} — ensemble not available`;
-      ensStatus.style.color = '#a77';
-    }
+    if (ensStatus) { ensStatus.textContent = `${modelLabel} — loading ensemble…`; ensStatus.style.color = '#888'; }
     document.getElementById('city-name').textContent =
       loc.name+(loc.country_code?', '+loc.country_code:'');
     document.getElementById('loading').style.display='none';
@@ -208,9 +228,11 @@ async function load(cityName, model) {
     forecastEl.classList.remove('updating');
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
-      ensTemp, ensWind, ensGust, ensPrecip,
+      detTemps, detWinds, detPrecips, detGusts,
+      ensTemp: null, ensWind: null, ensGust: null, ensPrecip: null,
       times1h, temps1h, precips1h, gusts1h, winds1h, codes1h, dirs1h,
-      ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
+      detTemps1h, detWinds1h, detPrecips1h, detGusts1h,
+      ensTemp1h: null, ensWind1h: null, ensGust1h: null, ensPrecip1h: null,
       otherModelsWind1h: null,
     };
     // Double rAF ensures layout is complete before measuring canvas width
@@ -226,10 +248,15 @@ async function load(cityName, model) {
         })
         .catch(() => null);
     }));
+    // Apply ensemble bands when ready; re-render once.
+    const capturedForEns = lastData;
+    ensPromise.then(ensData => {
+      if (lastData !== capturedForEns) return;
+      applyEnsembleData(lastData, ensData, model);
+      renderDisplay(lastData);
+    }).catch(() => null);
     // Load RainViewer radar centred on the selected city
     if (window.loadRadar) window.loadRadar(loc.latitude, loc.longitude);
-    // Find nearest obs station and overlay its wind history on the wind chart.
-    loadNearestObsStation(loc.latitude, loc.longitude).catch(() => null);
     updateShoreStatusUI();
   } catch(e) {
     console.error(e);
@@ -781,11 +808,13 @@ async function loadAtCoords(lat, lon, model, displayNameOverride) {
   try {
     window.SHORE_MASK   = null;
     window.SHORE_STATUS = { state: 'loading', msg: 'Fetching coastline…' };
-    // Coords are already known — start the Overpass fetch immediately so it
-    // runs in parallel with the reverse-geocode and weather requests.
+    // Coords are already known — start shore, ensemble, and obs lookups immediately
+    // so they run in parallel with the reverse-geocode and weather requests.
     lastShoreCoords = { lat, lon };
     if (window.fetchShoreVector) window.fetchShoreVector(lat, lon).catch(() => null);
     if (window.analyseShore)     window.analyseShore(lat, lon).catch(() => null);
+    const ensPromise = fetchEnsemble(lat, lon, model).catch(() => null);
+    loadNearestObsStation(lat, lon).catch(() => null);
 
     // Persist coords before any awaits: both a page reload and an iOS Home
     // Screen launch (which always opens the manifest start_url without query
@@ -818,9 +847,8 @@ async function loadAtCoords(lat, lon, model, displayNameOverride) {
       ? fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=weathercode&forecast_days=${FORECAST_DAYS}&timezone=auto&models=icon_seamless`)
           .then(r => r.ok ? r.json() : null).catch(() => null)
       : Promise.resolve(null);
-    const [data, ensData, iconData] = await Promise.all([
+    const [data, iconData] = await Promise.all([
       fetchWeather(lat, lon, model),
-      fetchEnsemble(lat, lon, model).catch(() => null),
       iconCodeFetch,
     ]);
     const H = data.hourly;
@@ -866,46 +894,13 @@ async function loadAtCoords(lat, lon, model, displayNameOverride) {
         ? iconCode1h : dmiCode1h);
       dirs1h.push(H.winddirection_10m[i]);
     }
-    const MODEL_LABEL = {
-      'best_match':          'Auto',      'dmi_seamless':        'DMI HARMONIE',
-      'icon_seamless':       'DWD ICON',  'ecmwf_ifs025':        'ECMWF IFS',
-      'meteofrance_seamless':'Météo-France', 'gfs_seamless':     'NOAA GFS',
-    };
-    const ENS_LABEL = {
-      'best_match':'ICON-EPS', 'dmi_seamless':'ICON-EPS', 'icon_seamless':'ICON-EPS',
-      'ecmwf_ifs025':'IFS-EPS', 'meteofrance_seamless':'ICON-EPS', 'gfs_seamless':'GFS-EPS',
-    };
+    const detTemps    = temps.slice(),    detWinds    = winds.slice();
+    const detPrecips  = precips.slice(),  detGusts    = gusts.slice();
+    const detTemps1h  = temps1h.slice(),  detWinds1h  = winds1h.slice();
+    const detPrecips1h = precips1h.slice(), detGusts1h = gusts1h.slice();
     const modelLabel = MODEL_LABEL[model] || model;
-    const ensLabel   = ENS_LABEL[model]   || 'ensemble';
-    let ensTemp=null,ensWind=null,ensGust=null,ensPrecip=null;
-    let ensTemp1h=null,ensWind1h=null,ensGust1h=null,ensPrecip1h=null;
     const ensStatus = document.getElementById('ens-status');
-    if (ensData && ensData.hourly) {
-      ensTemp    = ensemblePercentiles(ensData.hourly, 'temperature_2m');
-      ensWind    = ensemblePercentiles(ensData.hourly, 'windspeed_10m');
-      ensGust    = ensemblePercentiles(ensData.hourly, 'windgusts_10m');
-      ensPrecip  = ensemblePercentiles(ensData.hourly, 'precipitation');
-      ensTemp1h  = ensemblePercentiles(ensData.hourly, 'temperature_2m',  STEP1H);
-      ensWind1h  = ensemblePercentiles(ensData.hourly, 'windspeed_10m',   STEP1H);
-      ensGust1h  = ensemblePercentiles(ensData.hourly, 'windgusts_10m',   STEP1H);
-      ensPrecip1h= ensemblePercentiles(ensData.hourly, 'precipitation',   STEP1H);
-      const detGusts   = gusts.slice();
-      const detGusts1h = gusts1h.slice();
-      if (ensTemp)    for (let i=0;i<temps.length;  i++) { if (ensTemp.p50[i]   !=null) temps[i]  =ensTemp.p50[i];   }
-      if (ensWind)    for (let i=0;i<winds.length;  i++) { if (ensWind.p50[i]   !=null) winds[i]  =ensWind.p50[i];   }
-      if (ensPrecip)  for (let i=0;i<precips.length;i++) { if (ensPrecip.p50[i] !=null) precips[i]=ensPrecip.p50[i]; }
-      if (ensTemp1h)  for (let i=0;i<temps1h.length;  i++) { if (ensTemp1h.p50[i]  !=null) temps1h[i]  =ensTemp1h.p50[i];   }
-      if (ensWind1h)  for (let i=0;i<winds1h.length;  i++) { if (ensWind1h.p50[i]  !=null) winds1h[i]  =ensWind1h.p50[i];   }
-      if (ensPrecip1h)for (let i=0;i<precips1h.length;i++) { if (ensPrecip1h.p50[i]!=null) precips1h[i]=ensPrecip1h.p50[i]; }
-      for (let i=0;i<gusts.length;  i++) gusts[i]  =Math.max(detGusts[i],   winds[i]);
-      for (let i=0;i<gusts1h.length;i++) gusts1h[i]=Math.max(detGusts1h[i], winds1h[i]);
-      const memberCount = Object.keys(ensData.hourly).filter(k=>k.startsWith('temperature_2m_member')).length;
-      ensStatus.textContent = `${modelLabel} + ${ensLabel} (${memberCount} mdl) ✓`;
-      ensStatus.style.color = '#5a9';
-    } else {
-      ensStatus.textContent = `${modelLabel} — ensemble not available`;
-      ensStatus.style.color = '#a77';
-    }
+    if (ensStatus) { ensStatus.textContent = `${modelLabel} — loading ensemble…`; ensStatus.style.color = '#888'; }
     document.getElementById('city-name').textContent = displayName;
     document.getElementById('loading').style.display = 'none';
     forecastEl.style.display = 'block';
@@ -913,9 +908,11 @@ async function loadAtCoords(lat, lon, model, displayNameOverride) {
     const isFirstLoad = !isReload;
     lastData = {
       times, temps, precips, gusts, winds, dirs, codes,
-      ensTemp, ensWind, ensGust, ensPrecip,
+      detTemps, detWinds, detPrecips, detGusts,
+      ensTemp: null, ensWind: null, ensGust: null, ensPrecip: null,
       times1h, temps1h, precips1h, gusts1h, winds1h, codes1h, dirs1h,
-      ensTemp1h, ensWind1h, ensGust1h, ensPrecip1h,
+      detTemps1h, detWinds1h, detPrecips1h, detGusts1h,
+      ensTemp1h: null, ensWind1h: null, ensGust1h: null, ensPrecip1h: null,
       otherModelsWind1h: null,
     };
     requestAnimationFrame(() => requestAnimationFrame(() => {
@@ -930,6 +927,13 @@ async function loadAtCoords(lat, lon, model, displayNameOverride) {
         })
         .catch(() => null);
     }));
+    // Apply ensemble bands when ready; re-render once.
+    const capturedForEns = lastData;
+    ensPromise.then(ensData => {
+      if (lastData !== capturedForEns) return;
+      applyEnsembleData(lastData, ensData, model);
+      renderDisplay(lastData);
+    }).catch(() => null);
     // Call loadRadar only when the section is not yet visible (i.e. on a fresh
     // page load restored from a dragged-pin URL).  When called from a live drag
     // the radar is already initialised and correctly positioned, so skip it.
@@ -940,7 +944,6 @@ async function loadAtCoords(lat, lon, model, displayNameOverride) {
       }
     }
     updateShoreStatusUI();
-    loadNearestObsStation(lat, lon).catch(() => null);
   } catch(e) {
     console.error(e);
     document.getElementById('loading').style.display = 'none';
@@ -1397,6 +1400,14 @@ function decideInitialLocation(qParam, typedInput, savedCity) {
 window.onObsHistoryRefreshed = () => {
   if (lastObsCoords) loadNearestObsStation(lastObsCoords.lat, lastObsCoords.lon, { useCache: true }).catch(() => null);
 };
+
+// Re-fetch obs data whenever the page becomes visible again (e.g. returning to
+// a backgrounded PWA tab), ensuring the wind chart always shows current readings.
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible' && lastObsCoords) {
+    loadNearestObsStation(lastObsCoords.lat, lastObsCoords.lon).catch(() => null);
+  }
+});
 
 // Register service worker for PWA / offline support
 if ('serviceWorker' in navigator) {

--- a/radar.js
+++ b/radar.js
@@ -272,6 +272,7 @@ window._stationBias = _stationBias;
   function attachContextMenu(mapEl) {
     let ctxMenuEl = null;
     let pendingLatLng = null;
+    let _prefetchedName = null;
 
     function buildMenu() {
       const div = document.createElement('div');
@@ -296,7 +297,7 @@ window._stationBias = _stationBias;
       createSpotItem.addEventListener('click', () => {
         div.classList.remove('visible');
         if (pendingLatLng && window._onCreateKiteSpot) {
-          window._onCreateKiteSpot(pendingLatLng.lat, pendingLatLng.lng);
+          window._onCreateKiteSpot(pendingLatLng.lat, pendingLatLng.lng, _prefetchedName);
         }
       });
       div.appendChild(createSpotItem);
@@ -312,10 +313,22 @@ window._stationBias = _stationBias;
       pendingLatLng = radarMap.containerPointToLatLng(
         [clientX - rect.left, clientY - rect.top]
       );
-      // Prefetch shore data immediately so the Create kite spot modal shows
-      // the coastline without waiting for network requests after opening.
+      // Prefetch shore data and reverse-geocode the location so the Create kite
+      // spot modal opens with the coastline and a readable name already ready.
+      _prefetchedName = null;
       if (window.fetchShoreVector) window.fetchShoreVector(pendingLatLng.lat, pendingLatLng.lng).catch(() => null);
       if (window.analyseShore)     window.analyseShore(pendingLatLng.lat, pendingLatLng.lng).catch(() => null);
+      fetch(
+        `https://nominatim.openstreetmap.org/reverse?lat=${pendingLatLng.lat}&lon=${pendingLatLng.lng}&format=json&addressdetails=1`,
+        { headers: { 'Accept-Language': 'en' } }
+      ).then(r => r.ok ? r.json() : null).then(d => {
+        if (!d) return;
+        const a = d.address || {};
+        _prefetchedName = a.beach || a.leisure || a.natural
+                       || a.neighbourhood || a.suburb || a.hamlet || a.village
+                       || a.town || a.city_district || a.city
+                       || (d.display_name ? d.display_name.split(',')[0] : null) || null;
+      }).catch(() => null);
       const { x, y } = _clampMenuPos(clientX, clientY, window.innerWidth, window.innerHeight);
       ctxMenuEl.style.left = x + 'px';
       ctxMenuEl.style.top  = y + 'px';

--- a/radar.js
+++ b/radar.js
@@ -312,6 +312,10 @@ window._stationBias = _stationBias;
       pendingLatLng = radarMap.containerPointToLatLng(
         [clientX - rect.left, clientY - rect.top]
       );
+      // Prefetch shore data immediately so the Create kite spot modal shows
+      // the coastline without waiting for network requests after opening.
+      if (window.fetchShoreVector) window.fetchShoreVector(pendingLatLng.lat, pendingLatLng.lng).catch(() => null);
+      if (window.analyseShore)     window.analyseShore(pendingLatLng.lat, pendingLatLng.lng).catch(() => null);
       const { x, y } = _clampMenuPos(clientX, clientY, window.innerWidth, window.innerHeight);
       ctxMenuEl.style.left = x + 'px';
       ctxMenuEl.style.top  = y + 'px';

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -38,7 +38,8 @@ function makeEl(value = '') {
  * @param {boolean} opts.portrait     – simulate portrait orientation (default: false)
  * @param {Function|null} opts.renderAllSpy – optional spy to replace the renderAll stub
  */
-function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait = false, invertedColors = false, renderAllSpy = null, kiteDirs = [] } = {}) {
+function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait = false, invertedColors = false, renderAllSpy = null, kiteDirs = [],
+                   fetchWeatherImpl = null, fetchEnsembleImpl = null, rAFImmediate = false } = {}) {
   const cityInput         = makeEl();
   const geoCalls          = [];
   const replaceStateCalls = [];
@@ -135,14 +136,14 @@ function loadApp({ qParam = '', savedCity = null, geoAvailable = false, portrait
     encodeURIComponent, decodeURIComponent,
     Promise, Error,
     setTimeout, clearTimeout, performance,
-    requestAnimationFrame: () => {},
+    requestAnimationFrame: rAFImmediate ? (cb) => cb() : () => {},
     fetch: () => Promise.reject(new Error('fetch not mocked')),
     // Stubs for functions/constants defined in other scripts.
     // Use a never-settling promise so async chains stall silently rather than
     // logging unhandled-rejection noise to stderr.
     geocode:            () => new Promise(() => {}),
-    fetchWeather:       () => new Promise(() => {}),
-    fetchEnsemble:      () => new Promise(() => {}),
+    fetchWeather:       fetchWeatherImpl || (() => new Promise(() => {})),
+    fetchEnsemble:      fetchEnsembleImpl || (() => new Promise(() => {})),
     fetchOtherModelsWind: () => Promise.resolve([]),
     ensemblePercentiles: () => null,
     renderAll:          renderAllSpy || (() => {}),
@@ -1392,5 +1393,128 @@ describe('showCurrentTimeCrosshair', () => {
     };
     // mouseleave is no longer registered — crosshair stays wherever it was.
     expect(contentEl._listeners['mouseleave']).toBeUndefined();
+  });
+});
+
+// ── Progressive ensemble loading ──────────────────────────────────────────────
+
+describe('progressive ensemble loading', () => {
+  function makeMinimalWeatherData() {
+    const hours = 7 * 24;
+    const time = Array.from({ length: hours }, (_, i) =>
+      `2024-01-${String(Math.floor(i / 24) + 1).padStart(2, '0')}T${String(i % 24).padStart(2, '0')}:00`);
+    const vals = new Array(hours).fill(10);
+    return {
+      hourly: {
+        time,
+        temperature_2m:    vals,
+        precipitation:     vals.map(() => 0),
+        windspeed_10m:     vals,
+        windgusts_10m:     vals,
+        winddirection_10m: vals,
+        weathercode:       vals,
+      },
+      daily: {
+        sunrise: Array.from({ length: 7 }, (_, i) => `2024-01-${String(i + 1).padStart(2, '0')}T07:00`),
+        sunset:  Array.from({ length: 7 }, (_, i) => `2024-01-${String(i + 1).padStart(2, '0')}T16:00`),
+      },
+    };
+  }
+
+  function makeMinimalEnsData() {
+    const hours = 7 * 24;
+    const time = Array.from({ length: hours }, (_, i) =>
+      `2024-01-${String(Math.floor(i / 24) + 1).padStart(2, '0')}T${String(i % 24).padStart(2, '0')}:00`);
+    return { hourly: { time, temperature_2m_member01: new Array(hours).fill(10) } };
+  }
+
+  it('renders with deterministic data as soon as weather resolves, before ensemble', async () => {
+    let resolveWeather;
+    const weatherPromise = new Promise(r => { resolveWeather = r; });
+    const renderCalls = [];
+
+    const { ctx } = loadApp({
+      qParam: '55.0,12.0',
+      renderAllSpy: (...args) => renderCalls.push(args),
+      fetchWeatherImpl: () => weatherPromise,
+      // fetchEnsemble stays never-settling (default) to simulate slow ensemble
+      rAFImmediate: true,
+    });
+
+    expect(ctx.lastData).toBeNull();
+    expect(renderCalls).toHaveLength(0);
+
+    resolveWeather(makeMinimalWeatherData());
+    await new Promise(r => setTimeout(r, 0)); // drain microtasks
+
+    expect(ctx.lastData).not.toBeNull();
+    expect(ctx.lastData.ensTemp).toBeNull();
+    expect(ctx.lastData.ensWind).toBeNull();
+    // At least one render happened via the double-rAF path
+    expect(renderCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('triggers a second render with ensemble bands once ensemble resolves', async () => {
+    let resolveWeather, resolveEnsemble;
+    const weatherPromise  = new Promise(r => { resolveWeather  = r; });
+    const ensemblePromise = new Promise(r => { resolveEnsemble = r; });
+    const renderCalls = [];
+
+    const { ctx } = loadApp({
+      qParam: '55.0,12.0',
+      renderAllSpy: (...args) => renderCalls.push(args),
+      fetchWeatherImpl:  () => weatherPromise,
+      fetchEnsembleImpl: () => ensemblePromise,
+      rAFImmediate: true,
+    });
+
+    // Override ensemblePercentiles so applyEnsembleData returns non-null bands.
+    // This must be set before ensPromise resolves (done here before resolveEnsemble).
+    const hours = 7 * 24;
+    const fakePct = { p10: new Array(hours).fill(8), p50: new Array(hours).fill(10), p90: new Array(hours).fill(12) };
+    ctx.ensemblePercentiles = () => fakePct;
+
+    resolveWeather(makeMinimalWeatherData());
+    await new Promise(r => setTimeout(r, 0));
+
+    const rendersAfterWeather = renderCalls.length;
+    expect(ctx.lastData.ensTemp).toBeNull();
+
+    resolveEnsemble(makeMinimalEnsData());
+    await new Promise(r => setTimeout(r, 0));
+
+    // A second render was triggered after ensemble arrived
+    expect(renderCalls.length).toBeGreaterThan(rendersAfterWeather);
+    // Ensemble fields are now populated
+    expect(ctx.lastData.ensTemp).not.toBeNull();
+    expect(ctx.lastData.ensWind).not.toBeNull();
+  });
+
+  it('does not apply stale ensemble to a newer load', async () => {
+    let resolveWeather1, resolveEnsemble1;
+    const weather1  = new Promise(r => { resolveWeather1  = r; });
+    const ensemble1 = new Promise(r => { resolveEnsemble1 = r; });
+    const renderCalls = [];
+
+    const { ctx } = loadApp({
+      qParam: '55.0,12.0',
+      renderAllSpy: (...args) => renderCalls.push(args),
+      fetchWeatherImpl:  () => weather1,
+      fetchEnsembleImpl: () => ensemble1,
+      rAFImmediate: true,
+    });
+
+    resolveWeather1(makeMinimalWeatherData());
+    await new Promise(r => setTimeout(r, 0));
+    const dataAfterFirstLoad = ctx.lastData;
+
+    // Simulate a second load (different city) overwriting lastData
+    ctx.lastData = { placeholder: true };
+
+    // Now the stale ensemble from first load resolves — should be discarded
+    resolveEnsemble1(makeMinimalEnsData());
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(ctx.lastData).toEqual({ placeholder: true });
   });
 });


### PR DESCRIPTION
## Summary
Refactored ensemble data loading to be non-blocking, allowing the weather forecast to render immediately with deterministic data while ensemble bands are fetched and applied asynchronously. This improves perceived performance by showing the main forecast faster.

## Key Changes

- **Extracted `applyEnsembleData()` function**: Centralized ensemble processing logic that was duplicated in `load()` and `loadAtCoords()`. This function rebuilds merged center-line arrays from stored deterministic snapshots and updates the display with ensemble percentile bands.

- **Moved model/ensemble labels to module scope**: Extracted `MODEL_LABEL` and `ENS_LABEL` objects to the top level to avoid duplication across multiple functions.

- **Decoupled ensemble from critical path**: Ensemble fetches now run in parallel with weather requests but are no longer awaited in `Promise.all()`. Weather data renders immediately, then ensemble bands are applied in a separate `.then()` chain once available.

- **Store deterministic snapshots**: Both `load()` and `loadAtCoords()` now snapshot the original deterministic arrays (`detTemps`, `detWinds`, `detPrecips`, `detGusts`, etc.) before any ensemble merge, allowing `applyEnsembleData()` to correctly rebuild merged arrays when the ensemble promise resolves.

- **Prevent stale ensemble application**: Added a capture mechanism (`capturedForEns`) to ensure stale ensemble data from a previous load doesn't overwrite a newer forecast if the user navigates to a different location before the ensemble resolves.

- **Improved ensemble status messaging**: Status now shows "loading ensemble…" initially, then updates to either success or failure state once the ensemble promise settles.

- **Moved obs station lookup earlier**: `loadNearestObsStation()` is now started immediately alongside ensemble and shore fetches, rather than after the main render.

- **Added visibility change handler**: Re-fetches obs data when the page becomes visible again (e.g., returning to a backgrounded PWA tab), ensuring wind chart always shows current readings.

## Implementation Details

- The ensemble promise is captured before rendering and checked in the `.then()` handler to guard against stale data from previous loads.
- Deterministic gust values are preserved and only clamped against the (now ensemble-merged) wind line, maintaining the gust-wind gap.
- Tests added to verify progressive loading behavior: immediate render with deterministic data, second render when ensemble arrives, and prevention of stale ensemble application.

https://claude.ai/code/session_01623AeQps9ZbKfE46WZbYT7