### PR TITLE
Enhance kite spot bearing overlay with annular sectors and wind speed

### DIFF
--- a/app.js
+++ b/app.js
@@ -1099,8 +1099,8 @@ fetchCuratedKiteSpots().then(() => {
 });
 
 // Forward forecast hover events to the radar bearing overlay
-window.onForecastHover = (windDeg, isOptimal) => {
-  if (window.updateKiteSpotBearingHover) window.updateKiteSpotBearingHover(windDeg, isOptimal);
+window.onForecastHover = (windDeg, isOptimal, windSpeed) => {
+  if (window.updateKiteSpotBearingHover) window.updateKiteSpotBearingHover(windDeg, isOptimal, windSpeed);
 };
 
 // ── Initial load ──────────────────────────────────────────────────────────

--- a/radar.js
+++ b/radar.js
@@ -919,43 +919,23 @@ window._stationBias = _stationBias;
     if (_hoverOverlayLayer) { _hoverOverlayLayer.removeFrom(radarMap); _hoverOverlayLayer = null; }
   };
 
-  // Dynamic hover layer: wind bearing line + optional filled sector
-  window.updateKiteSpotBearingHover = function (windDeg, isOptimal) {
+  // Dynamic hover layer: wind bearing pie-piece colored by speed, radius scaled by kite minimum
+  window.updateKiteSpotBearingHover = function (windDeg, _isOptimal, windSpeed) {
     if (_hoverOverlayLayer) { _hoverOverlayLayer.removeFrom(radarMap); _hoverOverlayLayer = null; }
-    if (!_activeSpotState || windDeg == null || !radarMap) return;
+    if (!_activeSpotState || windDeg == null || windSpeed == null || !radarMap) return;
 
-    const { lat, lon, dirs } = _activeSpotState;
-    const R      = 6371000;
-    const latRad = lat * Math.PI / 180;
-    const radius = _bearingRadius();
-    const ang    = windDeg * Math.PI / 180;
-    const dlat   = (radius / R) * Math.cos(ang) * 180 / Math.PI;
-    const dlon   = (radius / R) * Math.sin(ang) / Math.cos(latRad) * 180 / Math.PI;
+    const { lat, lon } = _activeSpotState;
+    const radius = _bearingRadius() * windSpeed / KITE_CFG.min;
+    if (radius < 50) return;
 
-    const group = L.layerGroup();
-
-    // Dashed line from spot center toward wind source direction
-    L.polyline([[lat, lon], [lat + dlat, lon + dlon]], {
-      color:     isOptimal ? '#00c890' : '#888888',
-      weight:    1,
-      opacity:   0.9,
-      dashArray: '5,4',
-    }).addTo(group);
-
-    // Filled sector if wind snaps to a selected bearing and conditions are optimal
-    const snapped = Math.round(((windDeg % 360) + 360) % 360 / 10) * 10 % 360;
-    if (isOptimal && dirs.includes(snapped)) {
-      L.polygon(_bearingSectorLatLngs(lat, lon, snapped, radius), {
-        color:       '#00c890',
-        fillColor:   '#00c890',
-        fillOpacity: 0.35,
-        weight:      1,
-        opacity:     0.8,
-      }).addTo(group);
-    }
-
-    group.addTo(radarMap);
-    _hoverOverlayLayer = group;
+    const col = windColor(windSpeed);
+    _hoverOverlayLayer = L.polygon(_bearingSectorLatLngs(lat, lon, windDeg, radius), {
+      color:       col,
+      fillColor:   col,
+      fillOpacity: 0.55,
+      weight:      1.5,
+      opacity:     0.9,
+    }).addTo(radarMap);
   };
 
   let obsToggleCallback = null;

--- a/radar.js
+++ b/radar.js
@@ -939,21 +939,26 @@ window._stationBias = _stationBias;
     if (_hoverOverlayLayer) { _hoverOverlayLayer.removeFrom(radarMap); _hoverOverlayLayer = null; }
   };
 
-  // Dynamic hover layer: wind bearing pie-piece colored by speed, radius scaled by kite minimum
-  window.updateKiteSpotBearingHover = function (windDeg, _isOptimal, windSpeed) {
+  // Dynamic hover layer: annular ring slice, inner edge = icon boundary, outer scaled by speed
+  window.updateKiteSpotBearingHover = function (windDeg, isOptimal, windSpeed) {
     if (_hoverOverlayLayer) { _hoverOverlayLayer.removeFrom(radarMap); _hoverOverlayLayer = null; }
     if (!_activeSpotState || windDeg == null || windSpeed == null || !radarMap) return;
 
     const { lat, lon } = _activeSpotState;
-    const radius = _bearingRadius() * windSpeed / KITE_CFG.min;
-    if (radius < 50) return;
+    const base = _bearingRadius();
+
+    // Icon half-width in metres at current zoom (14 px for the 28 px kite spot icon)
+    const mPerPx      = (40075016.686 * Math.cos(lat * Math.PI / 180)) / (256 * Math.pow(2, radarMap.getZoom()));
+    const innerRadius = 14 * mPerPx;
+    const outerRadius = base * windSpeed / KITE_CFG.min;
+    if (outerRadius <= innerRadius) return;
 
     const snapped = Math.round(((windDeg % 360) + 360) % 360 / 10) * 10 % 360;
     const col = windColor(windSpeed);
-    _hoverOverlayLayer = L.polygon(_bearingSectorLatLngs(lat, lon, snapped, radius), {
+    _hoverOverlayLayer = L.polygon(_annularSectorLatLngs(lat, lon, snapped, innerRadius, outerRadius), {
       color:       col,
       fillColor:   col,
-      fillOpacity: 0.55,
+      fillOpacity: isOptimal ? 0.55 : 0,
       weight:      1.5,
       opacity:     0.9,
     }).addTo(radarMap);

--- a/radar.js
+++ b/radar.js
@@ -909,6 +909,7 @@ window._stationBias = _stationBias;
     if (!radarMap) { window._pendingBearingOverlay = { lat, lon, dirs }; return; }
     window._pendingBearingOverlay = null;
     _redrawBearingOutlines();
+    if (window.refireHoverIndicator) window.refireHoverIndicator();
   };
 
   window.hideKiteSpotBearingOverlay = function () {
@@ -929,7 +930,7 @@ window._stationBias = _stationBias;
     if (radius < 50) return;
 
     const col = windColor(windSpeed);
-    _hoverOverlayLayer = L.polygon(_bearingSectorLatLngs(lat, lon, windDeg, radius), {
+    _hoverOverlayLayer = L.polygon(_bearingSectorLatLngs(lat, lon, snapBearing(windDeg), radius), {
       color:       col,
       fillColor:   col,
       fillOpacity: 0.55,

--- a/radar.js
+++ b/radar.js
@@ -212,6 +212,22 @@ window._stationBias = _stationBias;
     return pts;
   }
 
+  /** Annular (ring) sector: outer arc then inner arc reversed, forming a truncated pie slice. */
+  function _annularSectorLatLngs(lat, lon, bearingDeg, innerRadiusM, outerRadiusM) {
+    const R      = 6371000;
+    const latRad = lat * Math.PI / 180;
+    const steps  = 8;
+    const pts    = [];
+    const _pt = (r, i) => {
+      const ang = ((bearingDeg - 5) + i * 10 / steps) * Math.PI / 180;
+      return [lat + (r / R) * Math.cos(ang) * 180 / Math.PI,
+              lon + (r / R) * Math.sin(ang) / Math.cos(latRad) * 180 / Math.PI];
+    };
+    for (let i = 0; i <= steps; i++) pts.push(_pt(outerRadiusM, i));
+    for (let i = steps; i >= 0; i--) pts.push(_pt(innerRadiusM, i));
+    return pts;
+  }
+
   /** Bearing sector radius: 5 km capped at 25% of the smaller map dimension. */
   function _bearingRadius() {
     const maxM = 5000;
@@ -887,14 +903,17 @@ window._stationBias = _stationBias;
     kiteSpotOutlineLayers = [];
     if (!_activeSpotState || !radarMap) return;
     const { lat, lon, dirs } = _activeSpotState;
-    const radius = _bearingRadius();
+    const base        = _bearingRadius();
+    const innerRadius = base;
+    const outerRadius = base * KITE_CFG.max / KITE_CFG.min;
     dirs.forEach(bearing => {
-      const latlngs = _bearingSectorLatLngs(lat, lon, bearing, radius);
+      const latlngs = _annularSectorLatLngs(lat, lon, bearing, innerRadius, outerRadius);
       const poly = L.polygon(latlngs, {
-        color:  '#00c890',
-        fill:   false,
-        weight: 1,
-        opacity: 0.75,
+        color:       '#00c890',
+        fillColor:   '#00c890',
+        fillOpacity: 0.25,
+        weight:      1,
+        opacity:     0.8,
       }).addTo(radarMap);
       kiteSpotOutlineLayers.push(poly);
     });
@@ -929,8 +948,9 @@ window._stationBias = _stationBias;
     const radius = _bearingRadius() * windSpeed / KITE_CFG.min;
     if (radius < 50) return;
 
+    const snapped = Math.round(((windDeg % 360) + 360) % 360 / 10) * 10 % 360;
     const col = windColor(windSpeed);
-    _hoverOverlayLayer = L.polygon(_bearingSectorLatLngs(lat, lon, snapBearing(windDeg), radius), {
+    _hoverOverlayLayer = L.polygon(_bearingSectorLatLngs(lat, lon, snapped, radius), {
       color:       col,
       fillColor:   col,
       fillOpacity: 0.55,

--- a/tooltip.js
+++ b/tooltip.js
@@ -97,8 +97,12 @@ function drawCrosshairs(fracX, idx1h, idx3h) {
   });
 }
 
+let _lastHoverIdx1h = null, _lastHoverIdx3h = null;
+
 function showTooltip(idx1h, idx3h) {
   if (!lastRenderedData) return;
+  _lastHoverIdx1h = idx1h;
+  _lastHoverIdx3h = idx3h;
   const d = lastRenderedData;
   const portrait = !!d.isPortraitMode;
   let timeStr, wind, dir;
@@ -113,6 +117,11 @@ function showTooltip(idx1h, idx3h) {
   }
   if (window.onForecastHover) window.onForecastHover(dir, isKiteOptimal(wind, dir, timeStr), wind);
 }
+
+window.refireHoverIndicator = function () {
+  if (_lastHoverIdx1h != null) showTooltip(_lastHoverIdx1h, _lastHoverIdx3h);
+  else showCurrentTimeCrosshair();
+};
 
 function showCurrentTimeCrosshair() {
   if (!lastRenderedData) { clearCrosshairs(); return; }

--- a/tooltip.js
+++ b/tooltip.js
@@ -111,7 +111,7 @@ function showTooltip(idx1h, idx3h) {
     wind    = d.winds1h[idx1h];
     dir     = d.dirs1h ? d.dirs1h[idx1h] : d.dirs[idx3h];
   }
-  if (window.onForecastHover) window.onForecastHover(dir, isKiteOptimal(wind, dir, timeStr));
+  if (window.onForecastHover) window.onForecastHover(dir, isKiteOptimal(wind, dir, timeStr), wind);
 }
 
 function showCurrentTimeCrosshair() {


### PR DESCRIPTION
## Summary
This PR enhances the kite spot bearing overlay visualization by replacing simple sector lines with annular (ring) sectors that scale based on wind speed, providing a more intuitive visual representation of wind conditions at kite spots.

## Key Changes

- **New annular sector geometry**: Added `_annularSectorLatLngs()` function to generate truncated pie-slice shapes (outer arc → inner arc reversed) instead of simple radial sectors
- **Wind speed-based scaling**: The hover indicator now scales the outer radius based on wind speed relative to minimum kite speed (`KITE_CFG.min`), with the inner radius matching the kite spot icon boundary
- **Enhanced hover visualization**: 
  - Replaced dashed bearing line + optional filled sector with a single annular sector
  - Inner radius dynamically calculated from icon size (14px) at current zoom level
  - Outer radius scales with wind speed
  - Color now uses `windColor(windSpeed)` for better wind condition indication
  - Fill opacity varies based on whether conditions are optimal (0.55) or not (0)
- **Improved data flow**: 
  - `updateKiteSpotBearingHover()` now accepts `windSpeed` parameter
  - `onForecastHover()` callback passes wind speed through the chain
  - Added `refireHoverIndicator()` to refresh hover state when bearing overlay is shown
- **Visual refinements**: Updated static bearing outline styling with fill color and adjusted opacity for better visibility

## Implementation Details

The annular sector uses the same bearing-based arc calculation as the original sector but generates two concentric arcs (outer then inner reversed) to create a filled ring slice. The hover indicator now provides immediate visual feedback about wind speed suitability for the selected kite spot.

https://claude.ai/code/session_01MLu645nh7R2QXDExyypE2p